### PR TITLE
Travis Configuration Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
-sudo: required
 jdk:
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:
    - $HOME/.m2


### PR DESCRIPTION
Travis does not support Oracle JDK 8 anymore. For that reason we switch to Open JDK.