### PR TITLE
Complete export declarations

### DIFF
--- a/bundles/emfprofiles/tools.vitruv.domains.emfprofiles/META-INF/MANIFEST.MF
+++ b/bundles/emfprofiles/tools.vitruv.domains.emfprofiles/META-INF/MANIFEST.MF
@@ -16,5 +16,6 @@ Require-Bundle: org.junit,
  org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,
  tools.vitruv.extensions.emf
-Export-Package: tools.vitruv.domains.emfprofiles
+Export-Package: tools.vitruv.domains.emfprofiles,
+ tools.vitruv.domains.emfprofiles.tuid;x-internal:=true
 Bundle-Vendor: vitruv.tools

--- a/bundles/java/tools.vitruv.domains.java.monitorededitor.astchangelistener/META-INF/MANIFEST.MF
+++ b/bundles/java/tools.vitruv.domains.java.monitorededitor.astchangelistener/META-INF/MANIFEST.MF
@@ -16,5 +16,8 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: tools.vitruv.domains.java.monitorededitor.astchangelistener,
- tools.vitruv.domains.java.monitorededitor.astchangelistener.classification
+ tools.vitruv.domains.java.monitorededitor.astchangelistener.activator;x-internal:=true,
+ tools.vitruv.domains.java.monitorededitor.astchangelistener.classification,
+ tools.vitruv.domains.java.monitorededitor.astchangelistener.classification.postchange;x-internal:=true,
+ tools.vitruv.domains.java.monitorededitor.astchangelistener.classification.postreconcile;x-internal:=true
 Bundle-Vendor: vitruv.tools

--- a/bundles/java/tools.vitruv.domains.java.monitorededitor.astchangelistener/plugin.xml
+++ b/bundles/java/tools.vitruv.domains.java.monitorededitor.astchangelistener/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-   <extension-point id="tools.vitruv.domains.java.monitorededitor.astchangelistener.classification.postreconcile" name="Postreconcile Classifiers" schema="schema/tools.vitruv.domains.java.monitorededitor.astchangelistener.postreconcile.exsd"/>
-   <extension-point id="tools.vitruv.domains.java.monitorededitor.astchangelistener.classification.postchange" name="Postchange Classifiers" schema="schema/tools.vitruv.domains.java.monitorededitor.astchangelistener.postchange.exsd"/>
+   <extension-point id="classification.postreconcile" name="Postreconcile Classifiers" schema="schema/tools.vitruv.domains.java.monitorededitor.astchangelistener.postreconcile.exsd"/>
+   <extension-point id="classification.postchange" name="Postchange Classifiers" schema="schema/tools.vitruv.domains.java.monitorededitor.astchangelistener.postchange.exsd"/>
 </plugin>

--- a/bundles/java/tools.vitruv.domains.java.monitorededitor.changeclassification/META-INF/MANIFEST.MF
+++ b/bundles/java/tools.vitruv.domains.java.monitorededitor.changeclassification/META-INF/MANIFEST.MF
@@ -11,5 +11,6 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: tools.vitruv.domains.java.monitorededitor.changeclassification,
- tools.vitruv.domains.java.monitorededitor.changeclassification.events
+ tools.vitruv.domains.java.monitorededitor.changeclassification.events,
+ tools.vitruv.domains.java.monitorededitor.changeclassification.events.util;x-internal:=true
 Bundle-Vendor: vitruv.tools

--- a/bundles/java/tools.vitruv.domains.java.monitorededitor.javamodel2ast/META-INF/MANIFEST.MF
+++ b/bundles/java/tools.vitruv.domains.java.monitorededitor.javamodel2ast/META-INF/MANIFEST.MF
@@ -11,5 +11,6 @@ Require-Bundle: org.eclipse.ui,
  org.apache.log4j;bundle-version="1.2.15"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Export-Package: tools.vitruv.domains.java.monitorededitor.javamodel2ast
+Export-Package: tools.vitruv.domains.java.monitorededitor.javamodel2ast,
+ tools.vitruv.domains.java.monitorededitor.javamodel2ast.activator;x-internal:=true
 Bundle-Vendor: vitruv.tools

--- a/bundles/java/tools.vitruv.domains.java.monitorededitor.methodchange/META-INF/MANIFEST.MF
+++ b/bundles/java/tools.vitruv.domains.java.monitorededitor.methodchange/META-INF/MANIFEST.MF
@@ -27,3 +27,7 @@ Require-Bundle: com.google.guava,
  org.emftext.language.java,
  tools.vitruv.framework.change
 Bundle-Vendor: vitruv.tools
+Export-Package: tools.vitruv.domains.java.monitorededitor.methodchange.changeclassifiers;x-internal:=true,
+ tools.vitruv.domains.java.monitorededitor.methodchange.changeresponder;x-internal:=true,
+ tools.vitruv.domains.java.monitorededitor.methodchange.events;x-internal:=true,
+ tools.vitruv.domains.java.monitorededitor.methodchange.utils;x-internal:=true

--- a/bundles/java/tools.vitruv.domains.java.monitorededitor.refactoringlistener/META-INF/MANIFEST.MF
+++ b/bundles/java/tools.vitruv.domains.java.monitorededitor.refactoringlistener/META-INF/MANIFEST.MF
@@ -19,6 +19,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Export-Package: tools.vitruv.domains.java.monitorededitor.refactoringlistener
+Export-Package: tools.vitruv.domains.java.monitorededitor.refactoringlistener,
+ tools.vitruv.domains.java.monitorededitor.refactoringlistener.activator;x-internal:=true,
+ tools.vitruv.domains.java.monitorededitor.refactoringlistener.refactoringParticipants;x-internal:=true
 Import-Package: org.apache.log4j
 Bundle-Vendor: vitruv.tools

--- a/bundles/java/tools.vitruv.domains.java.monitorededitor/META-INF/MANIFEST.MF
+++ b/bundles/java/tools.vitruv.domains.java.monitorededitor/META-INF/MANIFEST.MF
@@ -30,5 +30,6 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: tools.vitruv.domains.java.monitorededitor,
+ tools.vitruv.domains.java.monitorededitor.activator;x-internal:=true,
  tools.vitruv.domains.java.monitorededitor.jamopputil
 Bundle-Vendor: vitruv.tools

--- a/bundles/java/tools.vitruv.domains.java.monitorededitor/plugin.xml
+++ b/bundles/java/tools.vitruv.domains.java.monitorededitor/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
-   <extension-point id="tools.vitruv.domains.java.monitorededitor.changeeventextendedvisitors" name="Change Event Extended Visitors" schema="schema/tools.vitruv.domains.java.monitorededitor.changeeventextendedvisitors.exsd"/>
+   <extension-point id="changeeventextendedvisitors" name="Change Event Extended Visitors" schema="schema/tools.vitruv.domains.java.monitorededitor.changeeventextendedvisitors.exsd"/>
 </plugin>

--- a/bundles/java/tools.vitruv.domains.java/META-INF/MANIFEST.MF
+++ b/bundles/java/tools.vitruv.domains.java/META-INF/MANIFEST.MF
@@ -21,5 +21,6 @@ Require-Bundle: com.google.guava,
  org.eclipse.core.runtime,
  edu.kit.ipd.sdq.commons.util.java,
  tools.vitruv.domains.java.builder
-Export-Package: tools.vitruv.domains.java
+Export-Package: tools.vitruv.domains.java,
+ tools.vitruv.domains.java.tuid;x-internal:=true
 Bundle-Vendor: vitruv.tools

--- a/bundles/uml/tools.vitruv.domains.sysml/META-INF/MANIFEST.MF
+++ b/bundles/uml/tools.vitruv.domains.sysml/META-INF/MANIFEST.MF
@@ -17,5 +17,6 @@ Require-Bundle: tools.vitruv.domains.uml;visibility:=reexport,
  org.eclipse.papyrus.sysml14;visibility:=reexport,
  org.apache.log4j,
  tools.vitruv.extensions.emf
-Export-Package: tools.vitruv.domains.sysml
+Export-Package: tools.vitruv.domains.sysml,
+ tools.vitruv.domains.sysml.tuid;x-internal:=true
 Bundle-Vendor: vitruv.tools

--- a/bundles/uml/tools.vitruv.domains.uml/META-INF/MANIFEST.MF
+++ b/bundles/uml/tools.vitruv.domains.uml/META-INF/MANIFEST.MF
@@ -21,6 +21,7 @@ Require-Bundle: org.junit,
  org.eclipse.uml2.uml.resources,
  org.eclipse.osgi
 Comment: The above one is necessary because otherwise pathmap resources cannot be loaded
-Export-Package: tools.vitruv.domains.uml,
+Export-Package: org.eclipse.uml2.uml.internal.resource;x-internal:=true,
+ tools.vitruv.domains.uml,
  tools.vitruv.domains.uml.tuid
 Bundle-Vendor: vitruv.tools


### PR DESCRIPTION
This PR adds missing declarations of package exports (internal or not) marked as warnings in current Eclipse versions.
Additionally, it corrects two extension point specifications of the Java domain.