### PR TITLE
Fixed problem with unnamed Java packages & empty path segments

### DIFF
--- a/bundles/java/tools.vitruv.domains.java.util/src/tools/vitruv/domains/java/util/JavaPersistenceHelper.xtend
+++ b/bundles/java/tools.vitruv.domains.java.util/src/tools/vitruv/domains/java/util/JavaPersistenceHelper.xtend
@@ -3,23 +3,25 @@ package tools.vitruv.domains.java.util
 import org.emftext.language.java.containers.CompilationUnit
 
 class JavaPersistenceHelper {
+	private static val UNNAMED = "unnamedPackage"
+	
 	public static def String getJavaProjectSrc() {
 		return "src/";
 	}
-	
+
 	public static def String getPackageInfoClassName() {
 		"package-info"
-	} 
-	
+	}
+
 	public static def String buildJavaFilePath(String fileName, String... namespaces) {
 		return '''src/«FOR namespace : namespaces SEPARATOR "/" AFTER "/"»«namespace»«ENDFOR»«fileName»''';
 	}
-	
+
 	public static def String buildJavaFilePath(CompilationUnit compilationUnit) {
 		return '''src/«FOR namespace : compilationUnit.namespaces SEPARATOR "/" AFTER "/"»«namespace»«ENDFOR»«compilationUnit.name»''';
 	}
-	
+
 	public static def String buildJavaFilePath(org.emftext.language.java.containers.Package javaPackage) {
-		return '''src/«FOR namespace : javaPackage.namespaces SEPARATOR "/" AFTER "/"»«namespace»«ENDFOR»«javaPackage.name»/«packageInfoClassName».java''';
+		return '''src/«FOR namespace : javaPackage.namespaces SEPARATOR "/" AFTER "/"»«namespace»«ENDFOR»«javaPackage.name ?: UNNAMED»/«packageInfoClassName».java''';
 	}
 }


### PR DESCRIPTION
Fixed problem with the persistence of Java packages, which lead to invalid Java changes and as a result of the consistency preservation to duplicate UML packages. Unnamed Java packages produced a path that contained an empty segment (`//`) instead of a name, which then leads to applying changes, such as rename changes, to the parent package of the unnamed package. The empty segment was being ignored, and the resulting path matches the parent package: E.g. `/foo//` instead of `/foo/bar/`. These invalid changes propagated to the UML model and resulted in duplicate package names.

This problem was fixed by replacing the empty segment by any non-empty string (e.g. `//` => `/unnamedPackage/`). This placeholder is later replaced when the Java package is renamed.