### PR TITLE
Extend standard library loading in JaMoPP to support Java 9

### DIFF
--- a/bundles/java/tools.vitruv.domains.java/META-INF/MANIFEST.MF
+++ b/bundles/java/tools.vitruv.domains.java/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: com.google.guava,
  tools.vitruv.framework.vsum,
  org.eclipse.core.runtime,
  edu.kit.ipd.sdq.commons.util.java,
- tools.vitruv.domains.java.builder
+ tools.vitruv.domains.java.builder,
+ org.emftext.language.java.resource
 Export-Package: tools.vitruv.domains.java,
  tools.vitruv.domains.java.tuid;x-internal:=true
 Bundle-Vendor: vitruv.tools

--- a/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JamoppLibraryHelper.xtend
+++ b/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JamoppLibraryHelper.xtend
@@ -1,0 +1,40 @@
+package tools.vitruv.domains.java
+
+import org.emftext.language.java.JavaClasspath
+import org.emftext.language.java.JavaClasspath.Initializer
+import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.emf.common.util.URI
+
+/**
+ * This helper class allows to load the Java standard library in JaMoPP also with
+ * Java versions 9 and above.
+ * In Java 9 the boot classpath was removed and the standard library is packaged
+ * differently, which is corrected by this patch.
+ */
+class JamoppLibraryHelper {
+	public static String STANDARD_LIBRARY_PATH_IN_HOME = "/jmods/java.base.jmod";
+	
+	public static def void registerStdLib() {
+		val String javaVersion = System.getProperty("java.version");
+		
+		// Until Java 1.8 we can use the mechanism of JaMoPP
+		if (javaVersion.startsWith("1.")) {
+			JavaClasspath.get().registerStdLib();
+		// From Java 9 on, we have to search for the Java base module instead of the rt.jar file.
+		// To do so, we disable automatic initialization of the standard library using the classpath 
+		// (where library cannot be found in Java 9 and above) and manually load the base Java module
+		} else {
+			JavaClasspath.initializers.add(new Initializer() {
+				override initialize(Resource resource) {}
+				override requiresLocalClasspath() { false }
+				override requiresStdLib() { false }
+			})
+			val String classpath = System.getProperty("java.home") + STANDARD_LIBRARY_PATH_IN_HOME;
+			val uri = URI.createFileURI(classpath);
+			// From java 9, the module files do not directly contain the classes in the package structure
+			// but are placed in the "classes" folder, so that prefix has to be removed.
+			JavaClasspath.get().registerClassifierJar(uri, "classes/");
+		}
+	}
+
+}

--- a/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JavaDomain.xtend
+++ b/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JavaDomain.xtend
@@ -3,8 +3,9 @@ package tools.vitruv.domains.java
 import tools.vitruv.domains.java.tuid.JavaTuidCalculatorAndResolver
 import static tools.vitruv.domains.java.JavaNamespace.*
 import tools.vitruv.domains.java.builder.VitruviusJavaBuilderApplicator
-import org.emftext.language.java.JavaClasspath
 import tools.vitruv.framework.domains.AbstractTuidAwareVitruvDomain
+import org.eclipse.emf.ecore.resource.Resource
+import org.emftext.language.java.resource.JavaSourceOrClassFileResourceFactoryImpl
 
 final class JavaDomain extends AbstractTuidAwareVitruvDomain {
 	private static final String METAMODEL_NAME = "Java";
@@ -12,9 +13,11 @@ final class JavaDomain extends AbstractTuidAwareVitruvDomain {
 		
 	package new() {
 		super(METAMODEL_NAME, ROOT_PACKAGE, generateTuidCalculator(), #[FILE_EXTENSION]);
+		// Register factory for class and Java files in case of not running as plugin
+		Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put("java", new JavaSourceOrClassFileResourceFactoryImpl());
+		Resource.Factory.Registry.INSTANCE.getExtensionToFactoryMap().put("class", new JavaSourceOrClassFileResourceFactoryImpl());
 		// This is necessary to resolve classes from standard library (e.g. Object, List etc.) 
-		// when running as Plugin
-		JavaClasspath.get().registerStdLib
+		JamoppLibraryHelper.registerStdLib
 	}
 	
 	def protected static generateTuidCalculator() {


### PR DESCRIPTION
JaMoPP is not able to resolve the standard library using Java 9 and above. The library is not placed in the JRE folder anymore but provided in terms of modules.
We resolve that issue by adding the new path to the module library in the Java domain and overwriting the load mechanisms, as packaging is different in Java 9 and above (there is a folder prefix in the packaged file that has to be ignores for the class names).

This PR fixes issue #45.