### PR TITLE
Add Travis environment setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ notifications:
     
 before_install:
     - git clone --depth 1 https://github.com/kit-sdq/BuildUtilities.git /tmp/BuildUtilities
+    - . /tmp/BuildUtilities/travis-ci/setupenvironment.sh
     - "echo \"export MAVEN_OPTS='-Dmaven.repo.local=$HOME/.m2/repository -Xmx2g'\" > ~/.mavenrc"
 install: true
 


### PR DESCRIPTION
This allows to perform some environment setup on Travis, which is currently necessary because of the Maven 3.6.2 incompatibility with pomless Maven builds.