### PR TITLE
Eclipse 2020-06

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>1.5.1</version>
+    <version>2.0.0</version>
   </extension>
 </extensions>

--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.5.0</version>
+		<version>0.7.0</version>
 	</parent>
 	<artifactId>domains-parent</artifactId>
 	<version>0.3.0-SNAPSHOT</version>

--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
@@ -17,12 +17,6 @@
         <features name="org.emftext.commons.jdt.feature.group" versionRange="1.4.1"/>
         <features name="org.emftext.commons.layout.feature.group" versionRange="1.4.1"/>
       </repositories>
-      <repositories location="http://kit-sdq.github.io/updatesite/release/metamodels" mirrorArtifacts="false">
-        <features name="edu.kit.ipd.sdq.metamodels.families.feature.feature.group" versionRange="1.3.0" categories="//@customCategories[identifier='metamodels']"/>
-        <features name="edu.kit.ipd.sdq.metamodels.persons.feature.feature.group" versionRange="1.3.0" categories="//@customCategories[identifier='metamodels']"/>
-        <features name="edu.kit.ipd.sdq.metamodels.addresses.feature.feature.group" versionRange="1.3.0" categories="//@customCategories[identifier='metamodels']"/>
-        <features name="edu.kit.ipd.sdq.metamodels.recipients.feature.feature.group" versionRange="1.3.0" categories="//@customCategories[identifier='metamodels']"/>
-      </repositories>
       <repositories location="http://kit-sdq.github.io/updatesite/release/commons" mirrorArtifacts="false">
         <features name="edu.kit.ipd.sdq.commons.util.pcm.feature.feature.group" versionRange="1.5.0"/>
       </repositories>
@@ -51,5 +45,4 @@
   <configurations architecture="x86_64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="x86_64"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="x86_64"/>
-  <customCategories identifier="metamodels" label="SDQ Metamodels" description="Metamodels required for some of the Vitruv applications" features="//@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.3 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.2 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.1 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.0"/>
 </aggregator:Aggregation>

--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
@@ -18,10 +18,10 @@
         <features name="org.emftext.commons.layout.feature.group" versionRange="1.4.1"/>
       </repositories>
       <repositories location="http://kit-sdq.github.io/updatesite/release/metamodels" mirrorArtifacts="false">
-        <features name="edu.kit.ipd.sdq.metamodels.families.feature.feature.group" versionRange="1.1.0" categories="//@customCategories[identifier='metamodels']"/>
-        <features name="edu.kit.ipd.sdq.metamodels.persons.feature.feature.group" versionRange="1.1.0" categories="//@customCategories[identifier='metamodels']"/>
-        <features name="edu.kit.ipd.sdq.metamodels.addresses.feature.feature.group" versionRange="1.1.0" categories="//@customCategories[identifier='metamodels']"/>
-        <features name="edu.kit.ipd.sdq.metamodels.recipients.feature.feature.group" versionRange="1.1.0" categories="//@customCategories[identifier='metamodels']"/>
+        <features name="edu.kit.ipd.sdq.metamodels.families.feature.feature.group" versionRange="1.3.0" categories="//@customCategories[identifier='metamodels']"/>
+        <features name="edu.kit.ipd.sdq.metamodels.persons.feature.feature.group" versionRange="1.3.0" categories="//@customCategories[identifier='metamodels']"/>
+        <features name="edu.kit.ipd.sdq.metamodels.addresses.feature.feature.group" versionRange="1.3.0" categories="//@customCategories[identifier='metamodels']"/>
+        <features name="edu.kit.ipd.sdq.metamodels.recipients.feature.feature.group" versionRange="1.3.0" categories="//@customCategories[identifier='metamodels']"/>
       </repositories>
       <repositories location="http://kit-sdq.github.io/updatesite/release/commons" mirrorArtifacts="false">
         <features name="edu.kit.ipd.sdq.commons.util.pcm.feature.feature.group" versionRange="1.5.0"/>
@@ -29,21 +29,21 @@
       <repositories location="http://kastel-scbs.github.io/updatesite/nightly/confidentiality" mirrorArtifacts="false">
         <features name="edu.kit.kastel.scbs.confidentiality.feature.source.feature.group" versionRange="[1.0.0,2.0.0)"/>
       </repositories>
-      <repositories location="http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/2019-09" mirrorArtifacts="false">
+      <repositories location="http://download.eclipse.org/modeling/mdt/papyrus/updates/releases/2020-06" mirrorArtifacts="false">
         <features name="org.eclipse.papyrus.infra.core.feature.feature.group" versionRange="3.0.0"/>
         <features name="org.eclipse.papyrus.sdk.feature.feature.group" versionRange="4.2.0"/>
       </repositories>
       <repositories location="http://download.eclipse.org/modeling/mdt/papyrus/components/sysml14/2019-06" mirrorArtifacts="false">
         <features name="org.eclipse.papyrus.sysml14.feature.feature.group" versionRange="1.3.0"/>
       </repositories>
-      <repositories location="http://download.eclipse.org/releases/2019-09/" mirrorArtifacts="false">
-        <features name="org.eclipse.emf.ecore.edit.feature.group" versionRange="2.9.0"/>
-        <features name="org.eclipse.emf.ecore.feature.group" versionRange="2.19.0"/>
-        <features name="org.eclipse.emf.common.feature.group" versionRange="2.12.0"/>
-        <features name="org.eclipse.emf.transaction.feature.group" versionRange="1.11.0"/>
-        <features name="org.eclipse.xtend.sdk.feature.group" versionRange="2.19.0"/>
-        <features name="org.eclipse.xtext.ui.feature.group" versionRange="2.19.0"/>
-        <features name="org.eclipse.xtext.xbase.feature.group" versionRange="2.19.0"/>
+      <repositories location="http://download.eclipse.org/releases/2020-06/" mirrorArtifacts="false">
+        <features name="org.eclipse.emf.ecore.edit.feature.group" versionRange="2.14.0"/>
+        <features name="org.eclipse.emf.ecore.feature.group" versionRange="2.22.0"/>
+        <features name="org.eclipse.emf.common.feature.group" versionRange="2.19.0"/>
+        <features name="org.eclipse.emf.transaction.feature.group" versionRange="1.12.0"/>
+        <features name="org.eclipse.xtend.sdk.feature.group" versionRange="2.22.0"/>
+        <features name="org.eclipse.xtext.ui.feature.group" versionRange="2.22.0"/>
+        <features name="org.eclipse.xtext.xbase.feature.group" versionRange="2.22.0"/>
       </repositories>
     </contributions>
     <validationRepositories location="http://vitruv-tools.github.io/updatesite/nightly/framework"/>

--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
@@ -51,5 +51,5 @@
   <configurations architecture="x86_64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="x86_64"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="x86_64"/>
-  <customCategories identifier="metamodels" label="SDQ Metamodels" features="//@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.1 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.0 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.2 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.3"/>
+  <customCategories identifier="metamodels" label="SDQ Metamodels" description="Metamodels required for some of the Vitruv applications" features="//@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.3 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.2 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.1 //@validationSets[label='main']/@contributions[label='externals']/@repositories.2/@features.0"/>
 </aggregator:Aggregation>


### PR DESCRIPTION
This PR upgrades the parent POM version to 0.7.0, which improves dependencies to Eclipse 2020-06.

It also removes the updatesite category for demo metamodels, which is now provided by the framework updatesite, because the demo applications are part of the framework and not the CBSE case study.