### PR TITLE
Remove unnecessary modifiers

### DIFF
--- a/bundles/confidentiality/tools.vitruv.domains.confidentiality/src/tools/vitruv/domains/confidentiality/ConfidentialityDomainProvider.xtend
+++ b/bundles/confidentiality/tools.vitruv.domains.confidentiality/src/tools/vitruv/domains/confidentiality/ConfidentialityDomainProvider.xtend
@@ -3,9 +3,9 @@ package tools.vitruv.domains.confidentiality
 import tools.vitruv.framework.domains.VitruvDomainProvider
 
 class ConfidentialityDomainProvider implements VitruvDomainProvider<ConfidentialityDomain> {
-	private static var ConfidentialityDomain instance;
+	static var ConfidentialityDomain instance;
 	
-	override public ConfidentialityDomain getDomain() {
+	override ConfidentialityDomain getDomain() {
 		if (instance === null) {
 			instance = new ConfidentialityDomain();
 		}

--- a/bundles/emfprofiles/tools.vitruv.domains.emfprofiles/src-test/tools/vitruv/domains/emfprofiles/EmfProfilesDomainTest.xtend
+++ b/bundles/emfprofiles/tools.vitruv.domains.emfprofiles/src-test/tools/vitruv/domains/emfprofiles/EmfProfilesDomainTest.xtend
@@ -10,17 +10,17 @@ import org.modelversioning.emfprofileapplication.EMFProfileApplicationFactory
 import org.modelversioning.emfprofileapplication.ProfileImport
 
 class EmfProfilesDomainTest {
-	private static val TEST_PROFILE_NAME = "Test";
-	private var EmfProfilesDomain emfProfilesDomain;
+	static val TEST_PROFILE_NAME = "Test";
+	var EmfProfilesDomain emfProfilesDomain;
 	
 	@Before
-	public def void setup() {
+	def void setup() {
 		TuidManager.instance.reinitialize();
 		emfProfilesDomain = new EmfProfilesDomainProvider().domain;
 	}
 	
 	@Test
-	public def void testProfileImport() {
+	def void testProfileImport() {
 		val profileImport = createProfileImport;
 		profileImport.assertTuidCalculatability;
 		profileImport.profile = EMFProfileFactory.eINSTANCE.createProfile;
@@ -39,7 +39,7 @@ class EmfProfilesDomainTest {
 	}
 	
 	@Test
-	public def void testProfileApplication() {
+	def void testProfileApplication() {
 		val profileApplication = EMFProfileApplicationFactory.eINSTANCE.createProfileApplication();
 		profileApplication.assertTuidCalculatability
 		val profileImport = createProfileImport;
@@ -55,7 +55,7 @@ class EmfProfilesDomainTest {
 	}
 	
 	@Test
-	public def void testStereotypeApplication() {
+	def void testStereotypeApplication() {
 		val stereotypeApplication = EMFProfileApplicationFactory.eINSTANCE.createStereotypeApplication();
 		stereotypeApplication.assertTuidCalculatability;
 		// This has no name

--- a/bundles/emfprofiles/tools.vitruv.domains.emfprofiles/src/tools/vitruv/domains/emfprofiles/EmfProfilesDomainProvider.xtend
+++ b/bundles/emfprofiles/tools.vitruv.domains.emfprofiles/src/tools/vitruv/domains/emfprofiles/EmfProfilesDomainProvider.xtend
@@ -3,9 +3,9 @@ package tools.vitruv.domains.emfprofiles
 import tools.vitruv.framework.domains.VitruvDomainProvider
 
 class EmfProfilesDomainProvider implements VitruvDomainProvider<EmfProfilesDomain> {
-	private static var EmfProfilesDomain instance;
+	static var EmfProfilesDomain instance;
 	
-	override public EmfProfilesDomain getDomain() {
+	override EmfProfilesDomain getDomain() {
 		if (instance === null) {
 			instance = new EmfProfilesDomain();
 		}

--- a/bundles/java/tools.vitruv.domains.java.util/src/tools/vitruv/domains/java/util/JavaModificationUtil.xtend
+++ b/bundles/java/tools.vitruv.domains.java.util/src/tools/vitruv/domains/java/util/JavaModificationUtil.xtend
@@ -332,7 +332,7 @@ class JavaModificationUtil {
 			null !== field.typeReference.pureClassifierReference.target) {
 			val classifier = field.typeReference.pureClassifierReference.target
 			if (classifier instanceof Class) {
-				val jaMoPPClass = classifier as Class
+				val jaMoPPClass = classifier
 				val constructorsForClass = jaMoPPClass.members.filter(typeof(Constructor))
 				if (!constructorsForClass.nullOrEmpty) {
 					val constructorForClass = constructorsForClass.get(0)

--- a/bundles/java/tools.vitruv.domains.java.util/src/tools/vitruv/domains/java/util/JavaModificationUtil.xtend
+++ b/bundles/java/tools.vitruv.domains.java.util/src/tools/vitruv/domains/java/util/JavaModificationUtil.xtend
@@ -46,7 +46,7 @@ import org.emftext.language.java.references.ReferenceableElement
 
 @Utility 
 class JavaModificationUtil {
-	private static val Logger logger = Logger.getLogger(JavaModificationUtil)
+	static val Logger logger = Logger.getLogger(JavaModificationUtil)
 	
 	def static Parameter createOrdinaryParameter(TypeReference typeReference, String name) {
 		val parameter = ParametersFactory.eINSTANCE.createOrdinaryParameter
@@ -246,7 +246,7 @@ class JavaModificationUtil {
 		annotableAndModifiable.getAnnotationsAndModifiers().add(newAnnotation)
 	}
 
-	public def static addImportToClassFromString(ConcreteClassifier jaMoPPClass, List<String> namespaceArray,
+	def static addImportToClassFromString(ConcreteClassifier jaMoPPClass, List<String> namespaceArray,
 		String entityToImport) {
 		for (Import import : jaMoPPClass.containingCompilationUnit.imports) {
 			if ((import as ClassifierImport).classifier.name == entityToImport) {

--- a/bundles/java/tools.vitruv.domains.java.util/src/tools/vitruv/domains/java/util/JavaPersistenceHelper.xtend
+++ b/bundles/java/tools.vitruv.domains.java.util/src/tools/vitruv/domains/java/util/JavaPersistenceHelper.xtend
@@ -6,17 +6,17 @@ import org.emftext.language.java.containers.Package
 
 class JavaPersistenceHelper {
 
-	private static val UNNAMED_PACKAGE = "unnamedPackage"
+	static val UNNAMED_PACKAGE = "unnamedPackage"
 
 	public static val PATH_SEPARATOR = "/"
 	public static val FILE_EXTENSION_SEPARATOR = "."
 	public static val JAVA_FILE_EXTENSION = "java"
 
-	public static def String getJavaProjectSrc() {
+	static def String getJavaProjectSrc() {
 		return "src" + PATH_SEPARATOR;
 	}
 
-	public static def String getPackageInfoClassName() {
+	static def String getPackageInfoClassName() {
 		"package-info"
 	}
 
@@ -30,7 +30,7 @@ class JavaPersistenceHelper {
 		}
 	}
 
-	public static def stripJavaSourcePath(String javaFilePath, String sourcePath) {
+	static def stripJavaSourcePath(String javaFilePath, String sourcePath) {
 		if (javaFilePath.nullOrEmpty) return javaFilePath // null -> null, '' -> ''
 
 		// Get and return the path relative to the (normalized) source path:
@@ -47,12 +47,12 @@ class JavaPersistenceHelper {
 		}
 	}
 
-	public static def String buildJavaPath(String sourcePath, Iterable<String> namespaces) {
+	static def String buildJavaPath(String sourcePath, Iterable<String> namespaces) {
 		return buildJavaFilePath(sourcePath, namespaces, "", "")
 	}
 
 	// fileExtension can be empty and is then omitted.
-	public static def String buildJavaFilePath(String sourcePath, Iterable<String> namespaces, String fileName,
+	static def String buildJavaFilePath(String sourcePath, Iterable<String> namespaces, String fileName,
 		String fileExtension) {
 		return '''«sourcePath.normalizeSourcePath»«
 			FOR namespace : namespaces SEPARATOR PATH_SEPARATOR AFTER PATH_SEPARATOR»«namespace»«ENDFOR»«
@@ -63,28 +63,28 @@ class JavaPersistenceHelper {
 	// Uses 'src/' as source path.
 	// The fileName is simply appended to the end of the file path. It may or may not contain additional path segments
 	// and may or may not include the file extension.
-	public static def String buildJavaFilePath(String fileName, Iterable<String> namespaces) {
+	static def String buildJavaFilePath(String fileName, Iterable<String> namespaces) {
 		return buildJavaFilePath(javaProjectSrc, namespaces, fileName, null)
 	}
 
 	// Uses 'src/' as source path.
 	// The compilation unit name is expected to already include the file extension.
-	public static def String buildJavaFilePath(CompilationUnit compilationUnit) {
+	static def String buildJavaFilePath(CompilationUnit compilationUnit) {
 		return buildJavaFilePath(compilationUnit.name, compilationUnit.namespaces)
 	}
 
 	// Uses 'src/' as source path.
-	public static def String buildJavaFilePath(Package javaPackage) {
+	static def String buildJavaFilePath(Package javaPackage) {
 		return buildJavaPackageFilePath(javaProjectSrc, javaPackage.namespaces, javaPackage.name)
 	}
 
-	public static def String buildJavaPackageFilePath(String sourcePath, Iterable<String> namespaces,
+	static def String buildJavaPackageFilePath(String sourcePath, Iterable<String> namespaces,
 		String packageName) {
 		val fullNamespaces = getFullPackageNamespaces(namespaces, packageName)
 		return buildJavaFilePath(sourcePath, fullNamespaces, packageInfoClassName, JAVA_FILE_EXTENSION)
 	}
 
-	public static def String buildJavaPackagePath(String sourcePath, Iterable<String> namespaces,
+	static def String buildJavaPackagePath(String sourcePath, Iterable<String> namespaces,
 		String packageName) {
 		val fullNamespaces = getFullPackageNamespaces(namespaces, packageName)
 		return buildJavaPath(sourcePath, fullNamespaces)

--- a/bundles/java/tools.vitruv.domains.java/src-test/tools/vitruv/domains/java/JavaDomainTests.xtend
+++ b/bundles/java/tools.vitruv.domains.java/src-test/tools/vitruv/domains/java/JavaDomainTests.xtend
@@ -9,14 +9,14 @@ import org.eclipse.emf.ecore.EObject
 import org.emftext.language.java.classifiers.Classifier
 
 class JavaDomainTests {
-	private static val TEST_NAME = "Test";
+	static val TEST_NAME = "Test";
 	
 	private def JavaDomain getJavaDomain() {
 		return new JavaDomainProvider().getDomain();
 	}
 	
 	@Test
-	public def void testResponsibilityChecks() {
+	def void testResponsibilityChecks() {
 		val component = ClassifiersFactory.eINSTANCE.createClass();
 		val javaDomain = getJavaDomain();
 		Assert.assertTrue(javaDomain.isInstanceOfDomainMetamodel(component));
@@ -24,7 +24,7 @@ class JavaDomainTests {
 	}
 	
 	@Test
-	def public void testTuidInClassifiersPackage() {
+	def void testTuidInClassifiersPackage() {
 		testTuid(ClassifiersFactory.eINSTANCE.createClass());
 		testTuid(ClassifiersFactory.eINSTANCE.createInterface());
 	}

--- a/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JamoppLibraryHelper.xtend
+++ b/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JamoppLibraryHelper.xtend
@@ -14,7 +14,7 @@ import org.eclipse.emf.common.util.URI
 class JamoppLibraryHelper {
 	public static String STANDARD_LIBRARY_PATH_IN_HOME = "/jmods/java.base.jmod";
 	
-	public static def void registerStdLib() {
+	static def void registerStdLib() {
 		val String javaVersion = System.getProperty("java.version");
 		
 		// Until Java 1.8 we can use the mechanism of JaMoPP

--- a/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JavaDomain.xtend
+++ b/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JavaDomain.xtend
@@ -8,8 +8,8 @@ import org.eclipse.emf.ecore.resource.Resource
 import org.emftext.language.java.resource.JavaSourceOrClassFileResourceFactoryImpl
 
 final class JavaDomain extends AbstractTuidAwareVitruvDomain {
-	private static final String METAMODEL_NAME = "Java";
-	private boolean shouldTransitivelyPropagateChanges = false;
+	static final String METAMODEL_NAME = "Java";
+	boolean shouldTransitivelyPropagateChanges = false;
 		
 	package new() {
 		super(METAMODEL_NAME, ROOT_PACKAGE, generateTuidCalculator(), #[FILE_EXTENSION]);
@@ -36,7 +36,7 @@ final class JavaDomain extends AbstractTuidAwareVitruvDomain {
 	 * Calling this methods enable the per default disabled transitive change propagation.
 	 * Should only be called for test purposes!
 	 */
-	public def enableTransitiveChangePropagation() {
+	def enableTransitiveChangePropagation() {
 		shouldTransitivelyPropagateChanges = true
 	}
 	

--- a/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/tuid/JavaTuidCalculatorAndResolver.xtend
+++ b/bundles/java/tools.vitruv.domains.java/src/tools/vitruv/domains/java/tuid/JavaTuidCalculatorAndResolver.xtend
@@ -50,21 +50,21 @@ import org.emftext.language.java.references.ReferenceableElement
  */
 class JavaTuidCalculatorAndResolver extends HierarchicalTuidCalculatorAndResolver {
 
-	private val static Logger logger = Logger.getLogger(JavaTuidCalculatorAndResolver);
+	val static Logger logger = Logger.getLogger(JavaTuidCalculatorAndResolver);
 
-	private val String PARAMETER_SELECTOR = "parameter"
-	private val String CLASSIFIER_SELECTOR = "classifier"
-	private val String IMPORT_SELECTOR = "import"
-	private val String METHOD_SELECTOR = "method"
-	private val String FIELD_SELECTOR = "field"
-	private val String CONSTRUCTOR_SELECTOR = "constructor"
-	private val String ASSIGNMENT_EXPRESSION_SELECTOR = "assignmentExpression"
-	private val String EXPRESSION_STATEMENT_SELECTOR = "expressionStatement"
-	private val String SELF_REFERENCE_SELECTOR = "selfReference"
-	private val String STRING_REFERENCE_SELECTOR = "StringReference"
-	private val String IDENTIFIER_REFERENCE_SELECTOR = "identifierReference"
-	private val String NEW_CONSTRUCTOR_CALL_SELECTOR = "newConstructorCall"
-	private val String CONDITIONAL_EXPRESSION_SELECTOR = "conditionalExpression"
+	val String PARAMETER_SELECTOR = "parameter"
+	val String CLASSIFIER_SELECTOR = "classifier"
+	val String IMPORT_SELECTOR = "import"
+	val String METHOD_SELECTOR = "method"
+	val String FIELD_SELECTOR = "field"
+	val String CONSTRUCTOR_SELECTOR = "constructor"
+	val String ASSIGNMENT_EXPRESSION_SELECTOR = "assignmentExpression"
+	val String EXPRESSION_STATEMENT_SELECTOR = "expressionStatement"
+	val String SELF_REFERENCE_SELECTOR = "selfReference"
+	val String STRING_REFERENCE_SELECTOR = "StringReference"
+	val String IDENTIFIER_REFERENCE_SELECTOR = "identifierReference"
+	val String NEW_CONSTRUCTOR_CALL_SELECTOR = "newConstructorCall"
+	val String CONDITIONAL_EXPRESSION_SELECTOR = "conditionalExpression"
 	
 	new() {
 		super(METAMODEL_NAMESPACE)

--- a/bundles/pcm/tools.vitruv.domains.pcm/src-test/tools/vitruv/domains/pcm/PcmDomainTests.xtend
+++ b/bundles/pcm/tools.vitruv.domains.pcm/src-test/tools/vitruv/domains/pcm/PcmDomainTests.xtend
@@ -10,14 +10,14 @@ import org.junit.Test
 import org.palladiosimulator.pcm.repository.RepositoryPackage
 
 class PcmDomainTests {
-	private static val TEST_NAME = "Test";
+	static val TEST_NAME = "Test";
 	
 	private def PcmDomain getPcmDomain() {
 		return new PcmDomainProvider().getDomain();
 	}
 	
 	@Test
-	public def void testResponsibilityChecks() {
+	def void testResponsibilityChecks() {
 		val component = RepositoryFactory.eINSTANCE.createBasicComponent();
 		val pcmMetamodel = getPcmDomain();
 		Assert.assertTrue("Metamodel support only " + pcmMetamodel.nsUris + ", but not " + component.eClass.EPackage.nsURI + " of component",
@@ -29,7 +29,7 @@ class PcmDomainTests {
 	}
 	
 	@Test
-	def public void testIdentifierTuidInRepositoryPackage() {
+	def void testIdentifierTuidInRepositoryPackage() {
 		testIdentifierTuid(RepositoryFactory.eINSTANCE.createBasicComponent(), "BasicComponent");
 		testIdentifierTuid(RepositoryFactory.eINSTANCE.createCompositeComponent(), "CompositeComponent");
 		testIdentifierTuid(RepositoryFactory.eINSTANCE.createCollectionDataType(), "CollectionDataType");
@@ -38,7 +38,7 @@ class PcmDomainTests {
 	}
 	
 	@Test
-	def public void testNameTuidInRepositoryPackage() {
+	def void testNameTuidInRepositoryPackage() {
 		val parameter = RepositoryFactory.eINSTANCE.createParameter();
 		parameter.parameterName = TEST_NAME;
 		assertTuid(parameter, PcmPackage.eNS_URI, "<root>-_-Parameter-_-" + RepositoryPackage.Literals.PARAMETER__PARAMETER_NAME.name + "=" + parameter.parameterName);

--- a/bundles/pcm/tools.vitruv.domains.pcm/src/tools/vitruv/domains/pcm/PcmDomain.xtend
+++ b/bundles/pcm/tools.vitruv.domains.pcm/src/tools/vitruv/domains/pcm/PcmDomain.xtend
@@ -9,8 +9,8 @@ import tools.vitruv.domains.emf.builder.VitruviusEmfBuilderApplicator
 import tools.vitruv.framework.domains.AbstractTuidAwareVitruvDomain
 
 final class PcmDomain extends AbstractTuidAwareVitruvDomain {
-	private static final String METAMODEL_NAME = "PCM";
-	private boolean shouldTransitivelyPropagateChanges = false;
+	static final String METAMODEL_NAME = "PCM";
+	boolean shouldTransitivelyPropagateChanges = false;
 	
 	package new() {
 		super(METAMODEL_NAME, ROOT_PACKAGE, 
@@ -37,7 +37,7 @@ final class PcmDomain extends AbstractTuidAwareVitruvDomain {
 	 * Calling this methods enable the per default disabled transitive change propagation.
 	 * Should only be called for test purposes!
 	 */
-	public def enableTransitiveChangePropagation() {
+	def enableTransitiveChangePropagation() {
 		shouldTransitivelyPropagateChanges = true
 	}
 	

--- a/bundles/uml/tools.vitruv.domains.sysml/src-test/tools/vitruv/domains/sysml/SysMlDomainTests.xtend
+++ b/bundles/uml/tools.vitruv.domains.sysml/src-test/tools/vitruv/domains/sysml/SysMlDomainTests.xtend
@@ -15,18 +15,18 @@ import java.util.List
 import org.junit.Before
 
 class SysMlDomainTests {
-	private static val TEST_CLASS_NAME = "Test";
-	private var SysMlDomain sysMlDomain;
+	static val TEST_CLASS_NAME = "Test";
+	var SysMlDomain sysMlDomain;
 	
 	@Before
-	public def void setup() {
+	def void setup() {
 		TuidManager.instance.reinitialize
 		sysMlDomain = new SysMlDomainProvider().domain;
 		sysMlDomain.registerAtTuidManagement;
 	}
 	
 	@Test
-	public def void testTuidCalculationForUmlElemente() {
+	def void testTuidCalculationForUmlElemente() {
 		val clazz = UMLFactory.eINSTANCE.createClass();
 		clazz.name = TEST_CLASS_NAME;
 		testTuid(clazz, "Class", TEST_CLASS_NAME);
@@ -36,14 +36,14 @@ class SysMlDomainTests {
 	}
 	
 	@Test
-	public def void testTuidCalculationForSysMlElements() {
+	def void testTuidCalculationForSysMlElements() {
 		val block = createBlock();
 		testTuid(block, "Class", TEST_CLASS_NAME);
 		Assert.assertEquals(sysMlDomain.calculateTuid(block), sysMlDomain.calculateTuid(block.base_Class));
 	}
 	
 	@Test
-	public def void testResponsibilityChecks() {
+	def void testResponsibilityChecks() {
 		val block = createBlock();
 		Assert.assertTrue(sysMlDomain.isInstanceOfDomainMetamodel(block));
 		Assert.assertTrue(sysMlDomain.isInstanceOfDomainMetamodel(block.base_Class));
@@ -52,7 +52,7 @@ class SysMlDomainTests {
 	}
 	
 	@Test
-	public def void testTuidUpdate() {
+	def void testTuidUpdate() {
 		val List<String> tuids = new ArrayList<String>();
 		val dummyTuidUpdateListener = new TuidUpdateListener() {
 			override performPreAction(Tuid oldTuid) {

--- a/bundles/uml/tools.vitruv.domains.sysml/src/tools/vitruv/domains/sysml/SysMlDomainProvider.xtend
+++ b/bundles/uml/tools.vitruv.domains.sysml/src/tools/vitruv/domains/sysml/SysMlDomainProvider.xtend
@@ -3,9 +3,9 @@ package tools.vitruv.domains.sysml
 import tools.vitruv.framework.domains.VitruvDomainProvider
 
 class SysMlDomainProvider implements VitruvDomainProvider<SysMlDomain> {
-	private static var SysMlDomain instance;
+	static var SysMlDomain instance;
 	
-	override public SysMlDomain getDomain() {
+	override SysMlDomain getDomain() {
 		if (instance === null) {
 			instance = new SysMlDomain();
 		}

--- a/bundles/uml/tools.vitruv.domains.sysml/src/tools/vitruv/domains/sysml/tuid/SysMlToUmlResolver.xtend
+++ b/bundles/uml/tools.vitruv.domains.sysml/src/tools/vitruv/domains/sysml/tuid/SysMlToUmlResolver.xtend
@@ -7,11 +7,11 @@ import org.eclipse.papyrus.sysml14.portsandflows.FlowProperty
 import org.eclipse.papyrus.sysml14.blocks.BindingConnector
 
 final class SysMlToUmlResolver {
-	private static SysMlToUmlResolver instance;
+	static SysMlToUmlResolver instance;
 	
 	private new() {}
 	
-	public static def getInstance() {
+	static def getInstance() {
 		if (instance === null) {
 			instance = new SysMlToUmlResolver();
 		}

--- a/bundles/uml/tools.vitruv.domains.sysml/src/tools/vitruv/domains/sysml/tuid/SysMlTuidCalculatorAndResolver.xtend
+++ b/bundles/uml/tools.vitruv.domains.sysml/src/tools/vitruv/domains/sysml/tuid/SysMlTuidCalculatorAndResolver.xtend
@@ -5,7 +5,7 @@ import tools.vitruv.domains.sysml.SysMlDomain
 import tools.vitruv.domains.uml.tuid.UmlTuidCalculatorAndResolver
 
 class SysMlTuidCalculatorAndResolver extends UmlTuidCalculatorAndResolver {
-	private val extension SysMlToUmlResolver sysMlToUmlResolver;
+	val extension SysMlToUmlResolver sysMlToUmlResolver;
 
 	new(String nsPrefix) {
 		super(nsPrefix)

--- a/bundles/uml/tools.vitruv.domains.uml/src-test/tools/vitruv/domains/uml/UmlDomainTests.xtend
+++ b/bundles/uml/tools.vitruv.domains.uml/src-test/tools/vitruv/domains/uml/UmlDomainTests.xtend
@@ -7,7 +7,7 @@ import org.eclipse.uml2.uml.UMLPackage
 
 class UmlDomainTests {
 	@Test
-	public def void testTuidCalculator() {
+	def void testTuidCalculator() {
 		val clazz = UMLFactory.eINSTANCE.createClass();
 		clazz.name = "Test";
 		val tuidFragments = new UmlDomainProvider().domain.calculateTuid(clazz).toString.split("#");
@@ -18,7 +18,7 @@ class UmlDomainTests {
 	}
 	
 	@Test
-	public def void testGeneralizationTuidCalculation() {
+	def void testGeneralizationTuidCalculation() {
 		val superClass = UMLFactory.eINSTANCE.createClass();
 		superClass.name = "Super";
 		val subClass = UMLFactory.eINSTANCE.createClass();
@@ -37,7 +37,7 @@ class UmlDomainTests {
 	}
 	
 	@Test
-	public def void testGeneralizationGeneralOnlyTuidCalculation() {
+	def void testGeneralizationGeneralOnlyTuidCalculation() {
 		val superClass = UMLFactory.eINSTANCE.createClass();
 		superClass.name = "Super";
 		val generalization = UMLFactory.eINSTANCE.createGeneralization();
@@ -53,7 +53,7 @@ class UmlDomainTests {
 	}
 	
 	@Test
-	public def void testEmptyGeneralizationTuidCalculation() {
+	def void testEmptyGeneralizationTuidCalculation() {
 		val generalization = UMLFactory.eINSTANCE.createGeneralization();
 		// No classifiers the generalization belongs to
 		val tuidFragments = new UmlDomainProvider().domain.calculateTuid(generalization).toString.split("#");
@@ -66,7 +66,7 @@ class UmlDomainTests {
 	}
 	
 	@Test
-	public def void testEmptyPackageImportTuidCalculation() {
+	def void testEmptyPackageImportTuidCalculation() {
 		val import = UMLFactory.eINSTANCE.createPackageImport();
 		// No classifiers the generalization belongs to
 		val tuidFragments = new UmlDomainProvider().domain.calculateTuid(import).toString.split("#");
@@ -79,7 +79,7 @@ class UmlDomainTests {
 	}
 	
 	@Test
-	public def void testPackageImportTuidCalculation() {
+	def void testPackageImportTuidCalculation() {
 		val import = UMLFactory.eINSTANCE.createPackageImport();
 		val pckg = UMLFactory.eINSTANCE.createPackage();
 		pckg.name = "TestPackage";

--- a/bundles/uml/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/UmlDomain.xtend
+++ b/bundles/uml/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/UmlDomain.xtend
@@ -8,10 +8,10 @@ import tools.vitruv.domains.emf.builder.VitruviusEmfBuilderApplicator
 import tools.vitruv.framework.domains.AbstractTuidAwareVitruvDomain
 
 class UmlDomain extends AbstractTuidAwareVitruvDomain {
-	private static final String METAMODEL_NAME = "UML";
+	static final String METAMODEL_NAME = "UML";
 	public static val NAMESPACE_URIS = UMLPackage.eINSTANCE.nsURIsRecursive;
 	public static final String FILE_EXTENSION = UMLResource::FILE_EXTENSION;
-	private boolean shouldTransitivelyPropagateChanges = false;
+	boolean shouldTransitivelyPropagateChanges = false;
 
 	package new() {
 		super(METAMODEL_NAME, UMLPackage.eINSTANCE, generateTuidCalculator(), FILE_EXTENSION);
@@ -33,7 +33,7 @@ class UmlDomain extends AbstractTuidAwareVitruvDomain {
 	 * Calling this methods enable the per default disabled transitive change propagation.
 	 * Should only be called for test purposes!
 	 */
-	public def enableTransitiveChangePropagation() {
+	def enableTransitiveChangePropagation() {
 		shouldTransitivelyPropagateChanges = true
 	}
 	

--- a/bundles/uml/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/UmlDomainProvider.xtend
+++ b/bundles/uml/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/UmlDomainProvider.xtend
@@ -3,7 +3,7 @@ package tools.vitruv.domains.uml
 import tools.vitruv.framework.domains.VitruvDomainProvider
 
 class UmlDomainProvider implements VitruvDomainProvider<UmlDomain> {
-	private static var UmlDomain instance;
+	static var UmlDomain instance;
 	
 	override getDomain() {
 		if (instance === null) {


### PR DESCRIPTION
This PR removes several unnecessary modifiers in Xtend code, which resolves code style warnings in the Xtend default settings in Eclipse.