### PR TITLE
Incremental build and project refresh

### DIFF
--- a/bundles/java/tools.vitruv.domains.java.builder/src/tools/vitruv/domains/java/builder/JavaBuildOnEclipseStartup.java
+++ b/bundles/java/tools.vitruv.domains.java.builder/src/tools/vitruv/domains/java/builder/JavaBuildOnEclipseStartup.java
@@ -17,9 +17,9 @@ public class JavaBuildOnEclipseStartup implements IStartup {
 	@Override
 	public void earlyStartup() {
 		try {
-			ProjectBuildUtils.issueIncrementalBuildForAllProjectsWithBuilder(VitruviusJavaBuilder.BUILDER_ID);
+			ProjectBuildUtils.buildAllProjectsIncrementally(VitruviusJavaBuilder.BUILDER_ID);
 		} catch (IllegalStateException e) {
-			LOGGER.error("Could not issue initial build for all projects", e);
+			LOGGER.error("Could not perform initial build for all projects", e);
 		}
 	}
 }

--- a/bundles/java/tools.vitruv.domains.java.monitorededitor/src/tools/vitruv/domains/java/monitorededitor/MonitoredEditor.java
+++ b/bundles/java/tools.vitruv.domains.java.monitorededitor/src/tools/vitruv/domains/java/monitorededitor/MonitoredEditor.java
@@ -261,10 +261,17 @@ public class MonitoredEditor extends AbstractMonitoredEditor
 					Thread.sleep(200);
 				} catch (InterruptedException e) {
 				}
-				if (null != change) {
-					MonitoredEditor.this.virtualModel.propagateChange(change);
-				} else {
-					MonitoredEditor.this.virtualModel.propagateChange(MonitoredEditor.this.changeStash);
+				log.trace("Propagate monitored changes in projects " + Arrays.toString(monitoredProjectNames));
+				try {
+					if (null != change) {
+						MonitoredEditor.this.virtualModel.propagateChange(change);
+					} else {
+						MonitoredEditor.this.virtualModel.propagateChange(MonitoredEditor.this.changeStash);
+					}
+				} catch (Exception e) {
+					log.error("Some error occurred during propagating changes in projects "
+							+ Arrays.toString(monitoredProjectNames));
+					throw e;
 				}
 				return Status.OK_STATUS;
 			}


### PR DESCRIPTION
- Adapt to changed method signature for incremental project build
- Refresh projects before performing change propagation in `MonitoredEditor` for Java code
- Log errors during change propagation in `MonitoredEditor` for Java code, which were swallowed before