### PR TITLE
Avoid Locks in Java Monitored Editor to Allow Multiple Jobs Accessing It

### DIFF
--- a/bundles/tools.vitruv.domains.java.ui/src/tools/vitruv/domains/java/ui/monitorededitor/JavaMonitoredEditor.xtend
+++ b/bundles/tools.vitruv.domains.java.ui/src/tools/vitruv/domains/java/ui/monitorededitor/JavaMonitoredEditor.xtend
@@ -112,7 +112,7 @@ class JavaMonitoredEditor extends AbstractMonitoredEditor implements ChangeOpera
 		changePropagationJob.schedule()
 	}
 
-	private synchronized def void internalPropagateRecordedChanges() {
+	private def void internalPropagateRecordedChanges() {
 		log.debug('''Propagating «recordingState.changeCount» change(s) in projects «monitoredProjectNames»''')
 		val changes = recordingState.reset()
 		for (VitruviusChange change : changes) {


### PR DESCRIPTION
Processing a change event must be possible without locking the `JavaMonitoredEditor`. Otherwise a change propagation may be running (which needs to lock the `JavaMonitoredEditor`), but since it is run within a build `Job`, it in turn waits for the resource change `Job` to finish, which cannot proceed as it waits for the lock acquired by the change propagation `Job`. This is a classical deadlock.

In fact, we have used locking to avoid that multiple change processing or change propagation processes / jobs are running at the same time, whereas it should be specifically used to avoid race conditions and ensure memory consistency. This PR reduces the synchronization to what is absolutely necessary.