### PR TITLE
Fix Bug in Builder Aliveness Check

### DIFF
--- a/bundles/tools.vitruv.domains.emfprofiles/.classpath
+++ b/bundles/tools.vitruv.domains.emfprofiles/.classpath
@@ -20,7 +20,6 @@
 	</classpathentry>
 	<classpathentry kind="src" output="target/test-classes" path="src-test">
 		<attributes>
-			<attribute name="ignore_optional_problems" value="true"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/bundles/tools.vitruv.domains.java.ui/src/tools/vitruv/domains/java/ui/builder/VitruvJavaBuilder.java
+++ b/bundles/tools.vitruv.domains.java.ui/src/tools/vitruv/domains/java/ui/builder/VitruvJavaBuilder.java
@@ -47,6 +47,6 @@ public class VitruvJavaBuilder extends VitruvProjectBuilder {
 	}
 
 	private boolean isStillRegistered() {
-		return hasBuilder(getProject(), BUILDER_ID);
+		return getProject().isOpen() && hasBuilder(getProject(), BUILDER_ID);
 	}
 }

--- a/bundles/tools.vitruv.domains.java.ui/src/tools/vitruv/domains/java/ui/monitorededitor/JavaMonitoredEditor.xtend
+++ b/bundles/tools.vitruv.domains.java.ui/src/tools/vitruv/domains/java/ui/monitorededitor/JavaMonitoredEditor.xtend
@@ -119,7 +119,7 @@ class JavaMonitoredEditor extends AbstractMonitoredEditor implements ChangeOpera
 			try {
 				this.virtualModel.propagateChange(change)
 			} catch (Exception e) {
-				log.error('''Some error occurred during propagating changes in projects «monitoredProjectNames»''')
+				log.error('''Some error occurred during propagating changes in projects «monitoredProjectNames»''', e)
 				throw new IllegalStateException(e)
 			}
 		}


### PR DESCRIPTION
Fixes a bug that caused an exception when checking a project builder for being alive because of not checking project for being open.