### PR TITLE
Release 2.0.0

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tools.vitruv.domains.cbs</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>bundles</artifactId>
 	<packaging>pom</packaging>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tools.vitruv.domains.cbs</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>bundles</artifactId>
 	<packaging>pom</packaging>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tools.vitruv.domains.cbs</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 	<artifactId>bundles</artifactId>
 	<packaging>pom</packaging>

--- a/bundles/tools.vitruv.domains.emfprofiles/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.emfprofiles/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain EMF-Profiles
 Bundle-SymbolicName: tools.vitruv.domains.emfprofiles;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.emfprofiles
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,
  tools.vitruv.framework.domains;visibility:=reexport,

--- a/bundles/tools.vitruv.domains.emfprofiles/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.emfprofiles/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain EMF-Profiles
 Bundle-SymbolicName: tools.vitruv.domains.emfprofiles;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.emfprofiles
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,
  tools.vitruv.framework.domains;visibility:=reexport,

--- a/bundles/tools.vitruv.domains.emfprofiles/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.emfprofiles/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain EMF-Profiles
 Bundle-SymbolicName: tools.vitruv.domains.emfprofiles;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.emfprofiles
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,
  tools.vitruv.framework.domains;visibility:=reexport,

--- a/bundles/tools.vitruv.domains.java.echange/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java.echange/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.domains.java.echange;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.echange
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/tools.vitruv.domains.java.echange/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java.echange/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.domains.java.echange;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.echange
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/tools.vitruv.domains.java.echange/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java.echange/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: tools.vitruv.domains.java.echange;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.echange
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/tools.vitruv.domains.java.ui.methodchange/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java.ui.methodchange/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java UI Extension Method Changes
 Bundle-SymbolicName: tools.vitruv.domains.java.ui.methodchange;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.ui.monitorededitor.methodchange
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.core.resources,

--- a/bundles/tools.vitruv.domains.java.ui.methodchange/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java.ui.methodchange/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java UI Extension Method Changes
 Bundle-SymbolicName: tools.vitruv.domains.java.ui.methodchange;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.ui.monitorededitor.methodchange
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.core.resources,

--- a/bundles/tools.vitruv.domains.java.ui.methodchange/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java.ui.methodchange/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java UI Extension Method Changes
 Bundle-SymbolicName: tools.vitruv.domains.java.ui.methodchange;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.ui.monitorededitor.methodchange
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.core.resources,

--- a/bundles/tools.vitruv.domains.java.ui/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java UI
 Bundle-SymbolicName: tools.vitruv.domains.java.ui;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.ui
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-Activator: tools.vitruv.domains.java.ui.Activator
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.ui,

--- a/bundles/tools.vitruv.domains.java.ui/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java UI
 Bundle-SymbolicName: tools.vitruv.domains.java.ui;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.ui
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-Activator: tools.vitruv.domains.java.ui.Activator
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.ui,

--- a/bundles/tools.vitruv.domains.java.ui/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java UI
 Bundle-SymbolicName: tools.vitruv.domains.java.ui;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.ui
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Activator: tools.vitruv.domains.java.ui.Activator
 Require-Bundle: org.eclipse.xtend.lib,
  org.eclipse.ui,

--- a/bundles/tools.vitruv.domains.java/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java
 Bundle-SymbolicName: tools.vitruv.domains.java;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  edu.kit.ipd.sdq.activextendannotations,

--- a/bundles/tools.vitruv.domains.java/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java
 Bundle-SymbolicName: tools.vitruv.domains.java;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  edu.kit.ipd.sdq.activextendannotations,

--- a/bundles/tools.vitruv.domains.java/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.java/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java
 Bundle-SymbolicName: tools.vitruv.domains.java;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  edu.kit.ipd.sdq.activextendannotations,

--- a/bundles/tools.vitruv.domains.pcm/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.pcm/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain PCM
 Bundle-SymbolicName: tools.vitruv.domains.pcm;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.pcm
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  tools.vitruv.framework.domains;visibility:=reexport,

--- a/bundles/tools.vitruv.domains.pcm/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.pcm/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain PCM
 Bundle-SymbolicName: tools.vitruv.domains.pcm;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.pcm
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  tools.vitruv.framework.domains;visibility:=reexport,

--- a/bundles/tools.vitruv.domains.pcm/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.pcm/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain PCM
 Bundle-SymbolicName: tools.vitruv.domains.pcm;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.pcm
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  tools.vitruv.framework.domains;visibility:=reexport,

--- a/bundles/tools.vitruv.domains.sysml/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.sysml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain SysML
 Bundle-SymbolicName: tools.vitruv.domains.sysml;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.sysml
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  org.junit.jupiter.api,

--- a/bundles/tools.vitruv.domains.sysml/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.sysml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain SysML
 Bundle-SymbolicName: tools.vitruv.domains.sysml;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.sysml
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  org.junit.jupiter.api,

--- a/bundles/tools.vitruv.domains.sysml/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.sysml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain SysML
 Bundle-SymbolicName: tools.vitruv.domains.sysml;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.sysml
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  org.junit.jupiter.api,

--- a/bundles/tools.vitruv.domains.uml/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.uml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain UML
 Bundle-SymbolicName: tools.vitruv.domains.uml;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.uml
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: tools.vitruv.domains.uml.Activator

--- a/bundles/tools.vitruv.domains.uml/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.uml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain UML
 Bundle-SymbolicName: tools.vitruv.domains.uml;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.uml
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: tools.vitruv.domains.uml.Activator

--- a/bundles/tools.vitruv.domains.uml/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.domains.uml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain UML
 Bundle-SymbolicName: tools.vitruv.domains.uml;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.uml
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: tools.vitruv.domains.uml.Activator

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tools.vitruv.domains.cbs</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>features</artifactId>
 	<packaging>pom</packaging>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tools.vitruv.domains.cbs</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>features</artifactId>
 	<packaging>pom</packaging>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tools.vitruv.domains.cbs</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 	<artifactId>features</artifactId>
 	<packaging>pom</packaging>

--- a/features/tools.vitruv.domains.emfprofiles.feature/feature.xml
+++ b/features/tools.vitruv.domains.emfprofiles.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.emfprofiles.feature"
       label="%featureName"
-      version="2.0.0"
+      version="2.1.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.emfprofiles.feature/feature.xml
+++ b/features/tools.vitruv.domains.emfprofiles.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.emfprofiles.feature"
       label="%featureName"
-      version="1.1.0.qualifier"
+      version="2.0.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.emfprofiles.feature/feature.xml
+++ b/features/tools.vitruv.domains.emfprofiles.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.emfprofiles.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.java.feature/feature.xml
+++ b/features/tools.vitruv.domains.java.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.java.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.java.feature/feature.xml
+++ b/features/tools.vitruv.domains.java.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.java.feature"
       label="%featureName"
-      version="2.0.0"
+      version="2.1.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.java.feature/feature.xml
+++ b/features/tools.vitruv.domains.java.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.java.feature"
       label="%featureName"
-      version="1.1.0.qualifier"
+      version="2.0.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.pcm.feature/feature.xml
+++ b/features/tools.vitruv.domains.pcm.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.pcm.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.pcm.feature/feature.xml
+++ b/features/tools.vitruv.domains.pcm.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.pcm.feature"
       label="%featureName"
-      version="2.0.0"
+      version="2.1.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.pcm.feature/feature.xml
+++ b/features/tools.vitruv.domains.pcm.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.pcm.feature"
       label="%featureName"
-      version="1.1.0.qualifier"
+      version="2.0.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.sysml.feature/feature.xml
+++ b/features/tools.vitruv.domains.sysml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.sysml.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.sysml.feature/feature.xml
+++ b/features/tools.vitruv.domains.sysml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.sysml.feature"
       label="%featureName"
-      version="2.0.0"
+      version="2.1.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.sysml.feature/feature.xml
+++ b/features/tools.vitruv.domains.sysml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.sysml.feature"
       label="%featureName"
-      version="1.1.0.qualifier"
+      version="2.0.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.uml.feature/feature.xml
+++ b/features/tools.vitruv.domains.uml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.uml.feature"
       label="%featureName"
-      version="2.0.0.qualifier"
+      version="2.0.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.uml.feature/feature.xml
+++ b/features/tools.vitruv.domains.uml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.uml.feature"
       label="%featureName"
-      version="2.0.0"
+      version="2.1.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.domains.uml.feature/feature.xml
+++ b/features/tools.vitruv.domains.uml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.domains.uml.feature"
       label="%featureName"
-      version="1.1.0.qualifier"
+      version="2.0.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>domains-parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath>releng/tools.vitruv.domains.cbs.parent</relativePath>
 	</parent>
 	<artifactId>tools.vitruv.domains.cbs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>domains-parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 		<relativePath>releng/tools.vitruv.domains.cbs.parent</relativePath>
 	</parent>
 	<artifactId>tools.vitruv.domains.cbs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>domains-parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 		<relativePath>releng/tools.vitruv.domains.cbs.parent</relativePath>
 	</parent>
 	<artifactId>tools.vitruv.domains.cbs</artifactId>

--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -9,7 +9,7 @@
 		<version>1.1.1</version>
 	</parent>
 	<artifactId>domains-parent</artifactId>
-	<version>2.0.0-SNAPSHOT</version>
+	<version>2.0.0</version>
 	<packaging>pom</packaging>
 
 	<repositories>
@@ -17,7 +17,7 @@
 		<repository>
 			<id>Vitruv Framework</id>
 			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/nightly/framework/</url>
+			<url>https://vitruv-tools.github.io/updatesite/release/framework/2.0.0/</url>
 		</repository>
 		<repository>
 			<id>SDQ Commons</id>

--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -9,7 +9,7 @@
 		<version>1.1.1</version>
 	</parent>
 	<artifactId>domains-parent</artifactId>
-	<version>2.0.0</version>
+	<version>2.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<repositories>
@@ -17,7 +17,7 @@
 		<repository>
 			<id>Vitruv Framework</id>
 			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/release/framework/2.0.0/</url>
+			<url>https://vitruv-tools.github.io/updatesite/nightly/framework/</url>
 		</repository>
 		<repository>
 			<id>SDQ Commons</id>

--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -9,7 +9,7 @@
 		<version>1.1.1</version>
 	</parent>
 	<artifactId>domains-parent</artifactId>
-	<version>1.1.0-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<repositories>

--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>domains-parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath>../tools.vitruv.domains.cbs.parent</relativePath>
 	</parent>
 

--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>domains-parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 		<relativePath>../tools.vitruv.domains.cbs.parent</relativePath>
 	</parent>
 

--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>domains-parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 		<relativePath>../tools.vitruv.domains.cbs.parent</relativePath>
 	</parent>
 

--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
@@ -28,7 +28,7 @@
         <features name="org.eclipse.papyrus.sysml14.feature.feature.group"/>
       </repositories>
     </contributions>
-    <validationRepositories location="http://vitruv-tools.github.io/updatesite/release/framework/2.0.0"/>
+    <validationRepositories location="http://vitruv-tools.github.io/updatesite/nightly/framework"/>
     <validationRepositories location="http://download.eclipse.org/releases/2020-12"/>
   </validationSets>
   <configurations architecture="x86_64"/>

--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
@@ -28,7 +28,7 @@
         <features name="org.eclipse.papyrus.sysml14.feature.feature.group"/>
       </repositories>
     </contributions>
-    <validationRepositories location="http://vitruv-tools.github.io/updatesite/nightly/framework"/>
+    <validationRepositories location="http://vitruv-tools.github.io/updatesite/release/framework/2.0.0"/>
     <validationRepositories location="http://download.eclipse.org/releases/2020-12"/>
   </validationSets>
   <configurations architecture="x86_64"/>

--- a/releng/tools.vitruv.domains.cbs.updatesite/category.xml
+++ b/releng/tools.vitruv.domains.cbs.updatesite/category.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/tools.vitruv.domains.java.feature_1.1.0.qualifier.jar" id="tools.vitruv.domains.java.feature" version="1.1.0.qualifier">
+   <feature url="features/tools.vitruv.domains.java.feature_2.0.0.qualifier.jar" id="tools.vitruv.domains.java.feature" version="2.0.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.java.feature.source" version="1.1.0.qualifier">
+   <feature id="tools.vitruv.domains.java.feature.source" version="2.0.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.pcm.feature_1.1.0.qualifier.jar" id="tools.vitruv.domains.pcm.feature" version="1.1.0.qualifier">
+   <feature url="features/tools.vitruv.domains.pcm.feature_2.0.0.qualifier.jar" id="tools.vitruv.domains.pcm.feature" version="2.0.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.pcm.feature.source" version="1.1.0.qualifier">
+   <feature id="tools.vitruv.domains.pcm.feature.source" version="2.0.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.sysml.feature_1.1.0.qualifier.jar" id="tools.vitruv.domains.sysml.feature" version="1.1.0.qualifier">
+   <feature url="features/tools.vitruv.domains.sysml.feature_2.0.0.qualifier.jar" id="tools.vitruv.domains.sysml.feature" version="2.0.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.sysml.feature.source" version="1.1.0.qualifier">
+   <feature id="tools.vitruv.domains.sysml.feature.source" version="2.0.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.uml.feature_1.1.0.qualifier.jar" id="tools.vitruv.domains.uml.feature" version="1.1.0.qualifier">
+   <feature url="features/tools.vitruv.domains.uml.feature_2.0.0.qualifier.jar" id="tools.vitruv.domains.uml.feature" version="2.0.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.uml.feature.source" version="1.1.0.qualifier">
+   <feature id="tools.vitruv.domains.uml.feature.source" version="2.0.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.emfprofiles.feature_1.1.0.qualifier.jar" id="tools.vitruv.domains.emfprofiles.feature" version="1.1.0.qualifier">
+   <feature url="features/tools.vitruv.domains.emfprofiles.feature_2.0.0.qualifier.jar" id="tools.vitruv.domains.emfprofiles.feature" version="2.0.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.emfprofiles.feature.source" version="1.1.0.qualifier">
+   <feature id="tools.vitruv.domains.emfprofiles.feature.source" version="2.0.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
    <category-def name="Vitruv Domains CBS" label="Vitruv Domains: Component-based Systems">

--- a/releng/tools.vitruv.domains.cbs.updatesite/category.xml
+++ b/releng/tools.vitruv.domains.cbs.updatesite/category.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/tools.vitruv.domains.java.feature_2.0.0.qualifier.jar" id="tools.vitruv.domains.java.feature" version="2.0.0.qualifier">
+   <feature url="features/tools.vitruv.domains.java.feature_2.0.0.jar" id="tools.vitruv.domains.java.feature" version="2.0.0">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.java.feature.source" version="2.0.0.qualifier">
+   <feature id="tools.vitruv.domains.java.feature.source" version="2.0.0">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.pcm.feature_2.0.0.qualifier.jar" id="tools.vitruv.domains.pcm.feature" version="2.0.0.qualifier">
+   <feature url="features/tools.vitruv.domains.pcm.feature_2.0.0.jar" id="tools.vitruv.domains.pcm.feature" version="2.0.0">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.pcm.feature.source" version="2.0.0.qualifier">
+   <feature id="tools.vitruv.domains.pcm.feature.source" version="2.0.0">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.sysml.feature_2.0.0.qualifier.jar" id="tools.vitruv.domains.sysml.feature" version="2.0.0.qualifier">
+   <feature url="features/tools.vitruv.domains.sysml.feature_2.0.0.jar" id="tools.vitruv.domains.sysml.feature" version="2.0.0">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.sysml.feature.source" version="2.0.0.qualifier">
+   <feature id="tools.vitruv.domains.sysml.feature.source" version="2.0.0">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.uml.feature_2.0.0.qualifier.jar" id="tools.vitruv.domains.uml.feature" version="2.0.0.qualifier">
+   <feature url="features/tools.vitruv.domains.uml.feature_2.0.0.jar" id="tools.vitruv.domains.uml.feature" version="2.0.0">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.uml.feature.source" version="2.0.0.qualifier">
+   <feature id="tools.vitruv.domains.uml.feature.source" version="2.0.0">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.emfprofiles.feature_2.0.0.qualifier.jar" id="tools.vitruv.domains.emfprofiles.feature" version="2.0.0.qualifier">
+   <feature url="features/tools.vitruv.domains.emfprofiles.feature_2.0.0.jar" id="tools.vitruv.domains.emfprofiles.feature" version="2.0.0">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.emfprofiles.feature.source" version="2.0.0.qualifier">
+   <feature id="tools.vitruv.domains.emfprofiles.feature.source" version="2.0.0">
       <category name="Vitruv Domains CBS"/>
    </feature>
    <category-def name="Vitruv Domains CBS" label="Vitruv Domains: Component-based Systems">

--- a/releng/tools.vitruv.domains.cbs.updatesite/category.xml
+++ b/releng/tools.vitruv.domains.cbs.updatesite/category.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/tools.vitruv.domains.java.feature_2.0.0.jar" id="tools.vitruv.domains.java.feature" version="2.0.0">
+   <feature url="features/tools.vitruv.domains.java.feature_2.1.0.qualifier.jar" id="tools.vitruv.domains.java.feature" version="2.1.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.java.feature.source" version="2.0.0">
+   <feature id="tools.vitruv.domains.java.feature.source" version="2.1.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.pcm.feature_2.0.0.jar" id="tools.vitruv.domains.pcm.feature" version="2.0.0">
+   <feature url="features/tools.vitruv.domains.pcm.feature_2.1.0.qualifier.jar" id="tools.vitruv.domains.pcm.feature" version="2.1.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.pcm.feature.source" version="2.0.0">
+   <feature id="tools.vitruv.domains.pcm.feature.source" version="2.1.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.sysml.feature_2.0.0.jar" id="tools.vitruv.domains.sysml.feature" version="2.0.0">
+   <feature url="features/tools.vitruv.domains.sysml.feature_2.1.0.qualifier.jar" id="tools.vitruv.domains.sysml.feature" version="2.1.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.sysml.feature.source" version="2.0.0">
+   <feature id="tools.vitruv.domains.sysml.feature.source" version="2.1.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.uml.feature_2.0.0.jar" id="tools.vitruv.domains.uml.feature" version="2.0.0">
+   <feature url="features/tools.vitruv.domains.uml.feature_2.1.0.qualifier.jar" id="tools.vitruv.domains.uml.feature" version="2.1.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.uml.feature.source" version="2.0.0">
+   <feature id="tools.vitruv.domains.uml.feature.source" version="2.1.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature url="features/tools.vitruv.domains.emfprofiles.feature_2.0.0.jar" id="tools.vitruv.domains.emfprofiles.feature" version="2.0.0">
+   <feature url="features/tools.vitruv.domains.emfprofiles.feature_2.1.0.qualifier.jar" id="tools.vitruv.domains.emfprofiles.feature" version="2.1.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
-   <feature id="tools.vitruv.domains.emfprofiles.feature.source" version="2.0.0">
+   <feature id="tools.vitruv.domains.emfprofiles.feature.source" version="2.1.0.qualifier">
       <category name="Vitruv Domains CBS"/>
    </feature>
    <category-def name="Vitruv Domains CBS" label="Vitruv Domains: Component-based Systems">

--- a/releng/tools.vitruv.domains.cbs.updatesite/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>domains-parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 		<relativePath>../tools.vitruv.domains.cbs.parent</relativePath>
 	</parent>
 	

--- a/releng/tools.vitruv.domains.cbs.updatesite/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>domains-parent</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 		<relativePath>../tools.vitruv.domains.cbs.parent</relativePath>
 	</parent>
 	

--- a/releng/tools.vitruv.domains.cbs.updatesite/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>domains-parent</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath>../tools.vitruv.domains.cbs.parent</relativePath>
 	</parent>
 	

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tools.vitruv.domains.cbs</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>tests</artifactId>
 	<packaging>pom</packaging>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tools.vitruv.domains.cbs</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 	<artifactId>tests</artifactId>
 	<packaging>pom</packaging>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tools.vitruv.domains.cbs</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>tests</artifactId>
 	<packaging>pom</packaging>

--- a/tests/tools.vitruv.domains.java.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.domains.java.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java UI Tests
 Bundle-SymbolicName: tools.vitruv.domains.java.ui.tests;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.ui.tests
-Bundle-Version: 2.0.0
+Bundle-Version: 2.1.0.qualifier
 Fragment-Host: tools.vitruv.domains.java.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.text,

--- a/tests/tools.vitruv.domains.java.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.domains.java.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java UI Tests
 Bundle-SymbolicName: tools.vitruv.domains.java.ui.tests;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.ui.tests
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 2.0.0.qualifier
 Fragment-Host: tools.vitruv.domains.java.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.text,

--- a/tests/tools.vitruv.domains.java.ui.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.domains.java.ui.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv Domain Java UI Tests
 Bundle-SymbolicName: tools.vitruv.domains.java.ui.tests;singleton:=true
 Automatic-Module-Name: tools.vitruv.domains.java.ui.tests
-Bundle-Version: 2.0.0.qualifier
+Bundle-Version: 2.0.0
 Fragment-Host: tools.vitruv.domains.java.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.text,

--- a/tests/tools.vitruv.domains.java.ui.tests/pom.xml
+++ b/tests/tools.vitruv.domains.java.ui.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tests</artifactId>
-		<version>2.0.0-SNAPSHOT</version>
+		<version>2.0.0</version>
 	</parent>
 	<artifactId>tools.vitruv.domains.java.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/tests/tools.vitruv.domains.java.ui.tests/pom.xml
+++ b/tests/tools.vitruv.domains.java.ui.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tests</artifactId>
-		<version>1.1.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>tools.vitruv.domains.java.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/tests/tools.vitruv.domains.java.ui.tests/pom.xml
+++ b/tests/tools.vitruv.domains.java.ui.tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tests</artifactId>
-		<version>2.0.0</version>
+		<version>2.1.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>tools.vitruv.domains.java.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>


### PR DESCRIPTION
This PR releases version 2.0.0 and increases the development version 2.1.0.
We have made API-breaking changes in both reexported packages of the framework (which also upgraded from 1.0.0 to 2.0.0) as well as in the domains themselves. This especially concerns the completely restructured Java domain.