### PR TITLE
Eclipse as Mapped Repository in Aggregated Updatesite

### DIFF
--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
@@ -27,9 +27,11 @@
       <repositories location="http://download.eclipse.org/modeling/mdt/papyrus/components/sysml14/2019-06" mirrorArtifacts="false">
         <features name="org.eclipse.papyrus.sysml14.feature.feature.group"/>
       </repositories>
+      <repositories location="http://download.eclipse.org/releases/2020-12" mirrorArtifacts="false">
+        <features name="org.eclipse.uml2.uml.feature.group"/>
+      </repositories>
     </contributions>
     <validationRepositories location="http://vitruv-tools.github.io/updatesite/nightly/framework"/>
-    <validationRepositories location="http://download.eclipse.org/releases/2020-12"/>
   </validationSets>
   <configurations architecture="x86_64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="x86_64"/>


### PR DESCRIPTION
Adds Eclipse as mapped repository to aggregated updatesite to enable resolution of referenced artifacts when setting up target platform.