### PR TITLE
Perform applications validation on pull request

### DIFF
--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -7,13 +7,6 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Framework
-        uses: actions/checkout@v2
-        with:
-          path: framework
-          repository: vitruv-tools/Vitruv
-          ref: master
-          fetch-depth: 0
       - name: Checkout CBS Domains
         uses: actions/checkout@v2
         with:
@@ -41,27 +34,8 @@ jobs:
           java-version: 11
       - name: Adapt Updatesites
         run: |
-          sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/framework/#file:///${maven.multiModuleProjectDirectory}/../framework/releng/tools.vitruv.updatesite.aggregated/target/final#wresult' cbsdomains/releng/tools.vitruv.domains.cbs.parent/pom.xml
-          if [ ! -s result ]; then exit 1; fi;
-          sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/framework/#file:///${maven.multiModuleProjectDirectory}/../framework/releng/tools.vitruv.updatesite.aggregated/target/final#wresult' cbsapplications/releng/tools.vitruv.applications.cbs.parent/pom.xml
-          if [ ! -s result ]; then exit 1; fi;
           sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/#file:///${maven.multiModuleProjectDirectory}/../cbsdomains/releng/tools.vitruv.domains.cbs.updatesite.aggregated/target/final#wresult' cbsapplications/releng/tools.vitruv.applications.cbs.parent/pom.xml
           if [ ! -s result ]; then exit 1; fi;
-      - name: Build Framework
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          working-directory: ./framework
-          run: >
-            ./mvnw -B package -Dmaven.test.skip=true
-            -Dstyle.color=always
-            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
-            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
-            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
-        env: 
-          MAVEN_OPTS: -Djansi.force=true
       - name: Build Domains
         working-directory: ./cbsdomains
         run: >

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -7,6 +7,13 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Framework
+        uses: actions/checkout@v2
+        with:
+          path: framework
+          repository: vitruv-tools/Vitruv
+          ref: master
+          fetch-depth: 0
       - name: Checkout CBS Domains
         uses: actions/checkout@v2
         with:
@@ -34,10 +41,27 @@ jobs:
           java-version: 11
       - name: Adapt Updatesites
         run: |
+          sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/framework/#file:///${maven.multiModuleProjectDirectory}/../framework/releng/tools.vitruv.updatesite.aggregated/target/final#wresult' cbsdomains/releng/tools.vitruv.domains.cbs.parent/pom.xml
+          if [ ! -s result ]; then exit 1; fi;
           sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/framework/#file:///${maven.multiModuleProjectDirectory}/../framework/releng/tools.vitruv.updatesite.aggregated/target/final#wresult' cbsapplications/releng/tools.vitruv.applications.cbs.parent/pom.xml
           if [ ! -s result ]; then exit 1; fi;
           sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/#file:///${maven.multiModuleProjectDirectory}/../cbsdomains/releng/tools.vitruv.domains.cbs.updatesite.aggregated/target/final#wresult' cbsapplications/releng/tools.vitruv.applications.cbs.parent/pom.xml
           if [ ! -s result ]; then exit 1; fi;
+      - name: Build Framework
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          working-directory: ./framework
+          run: >
+            ./mvnw -B package -Dmaven.test.skip=true
+            -Dstyle.color=always
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+        env: 
+          MAVEN_OPTS: -Djansi.force=true
       - name: Build Domains
         working-directory: ./cbsdomains
         run: >

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -1,0 +1,68 @@
+name: Application Validation
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout CBS Domains
+        uses: actions/checkout@v2
+        with:
+          path: cbsdomains
+      - name: Checkout CBS Applications
+        uses: actions/checkout@v2
+        with:
+          path: cbsapplications
+          repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
+          ref: master
+          fetch-depth: 0
+      - name: Checkout Matching Applications Branch
+        run: |
+          cd ../cbsapplications
+          git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Adapt Updatesites
+        run: |
+          sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/framework/#file:///${maven.multiModuleProjectDirectory}/../framework/releng/tools.vitruv.updatesite.aggregated/target/final#wresult' cbsapplications/releng/tools.vitruv.applications.cbs.parent/pom.xml
+          if [ ! -s result ]; then exit 1; fi;
+          sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/#file:///${maven.multiModuleProjectDirectory}/../cbsdomains/releng/tools.vitruv.domains.cbs.updatesite.aggregated/target/final#wresult' cbsapplications/releng/tools.vitruv.applications.cbs.parent/pom.xml
+          if [ ! -s result ]; then exit 1; fi;
+      - name: Build Domains
+        working-directory: ./cbsdomains
+        run: >
+            ./mvnw -B package -Dmaven.test.skip=true
+            -Dstyle.color=always
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+        env: 
+          MAVEN_OPTS: -Djansi.force=true
+      - name: Build Applications
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          working-directory: ./cbsapplications
+          run: >
+            ./mvnw -B clean verify
+            -Dstyle.color=always
+            -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.osgi.configuration.MavenContextConfigurator=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.sisu.equinox.launching.internal.DefaultEquinoxLauncher=warn
+            -Dorg.slf4j.simpleLogger.log.org.eclipse.xtext.maven.XtextGenerateMojo=warn
+            -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.NoOpLog
+        env: 
+          MAVEN_OPTS: -Djansi.force=true

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout Matching Applications Branch
         run: |
-          cd ../cbsapplications
+          cd cbsapplications
           git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
       - name: Cache
         uses: actions/cache@v2


### PR DESCRIPTION
Perform application validation on every pull request to avoid cases like in #101.
Like in the framework repository application validation, uses the branch matching the current branch name in the application's repository (if any), otherwise the master branch. Always uses the framework master branch to enforce merge order framework -> domains -> applications.