### PR TITLE
Eclipse 2021-06

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.0.0</version>
+    <version>2.3.0</version>
   </extension>
 </extensions>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -38,7 +38,7 @@
 		<repository>
 			<id>Palladiosimulator</id>
 			<layout>p2</layout>
-			<url>https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/4.3.0/</url>
+			<url>https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/5.0.0/</url>
 		</repository>
 	</repositories>
 

--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.1.1</version>
+		<version>1.3.0</version>
 	</parent>
 	<artifactId>domains-parent</artifactId>
 	<version>2.1.0-SNAPSHOT</version>

--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
@@ -20,7 +20,7 @@
       <repositories location="http://kit-sdq.github.io/updatesite/release/commons/2.0.0" mirrorArtifacts="false">
         <features name="edu.kit.ipd.sdq.commons.util.pcm.feature.feature.group"/>
       </repositories>
-      <repositories location="http://download.eclipse.org/releases/2020-12" mirrorArtifacts="false">
+      <repositories location="http://download.eclipse.org/releases/2021-06" mirrorArtifacts="false">
         <features name="org.eclipse.uml2.uml.feature.group"/>
       </repositories>
     </contributions>

--- a/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
+++ b/releng/tools.vitruv.domains.cbs.updatesite.aggregated/updatesite.aggr
@@ -5,7 +5,7 @@
       <repositories location="../tools.vitruv.domains.cbs.updatesite/target/repository"/>
     </contributions>
     <contributions label="externals">
-      <repositories location="https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/4.3.0">
+      <repositories location="https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/5.0.0">
         <features name="de.uka.ipd.sdq.identifier.feature.feature.group" versionRange="2.1.0"/>
         <features name="org.palladiosimulator.pcm.feature.feature.group" versionRange="4.3.0"/>
       </repositories>


### PR DESCRIPTION
Increases parent POM version to 1.3.0 (Eclipse 2021-06) and increases PCM dependency to 5.0.0 (latest release).