### PR TITLE
Use dynamic dispatch for file path creation of Java root elements

### DIFF
--- a/bundles/tools.vitruv.domains.java/src/tools/vitruv/domains/java/util/JavaPersistenceHelper.xtend
+++ b/bundles/tools.vitruv.domains.java/src/tools/vitruv/domains/java/util/JavaPersistenceHelper.xtend
@@ -79,12 +79,12 @@ class JavaPersistenceHelper {
 	}
 		
 	// Uses 'src/' as source path.
-	static def String buildJavaFilePath(CompilationUnit compilationUnit) {
+	static def dispatch String buildJavaFilePath(CompilationUnit compilationUnit) {
 		return buildJavaFilePath(javaProjectSrc, compilationUnit.namespaces, compilationUnit.simpleName, JAVA_FILE_EXTENSION)
 	}
 
 	// Uses 'src/' as source path.
-	static def String buildJavaFilePath(Package javaPackage) {
+	static def dispatch String buildJavaFilePath(Package javaPackage) {
 		return buildJavaPackageFilePath(javaProjectSrc, javaPackage.namespaces, javaPackage.name)
 	}
 


### PR DESCRIPTION
This allows to pass any kind of `JavaRoot` to the method for retrieving the according file path, thus allowing generic handling of all kinds of `JavaRoot` elements in persistence logic.