### PR TITLE
Add functionality for disabling transitive change propagation

### DIFF
--- a/bundles/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JavaDomain.xtend
+++ b/bundles/tools.vitruv.domains.java/src/tools/vitruv/domains/java/JavaDomain.xtend
@@ -30,11 +30,20 @@ class JavaDomain extends AbstractVitruvDomain {
 	}
 	
 	/**
-	 * Calling this methods enable the per default disabled transitive change propagation.
+	 * Calling this method enables the per default disabled transitive change propagation.
 	 * Should only be called for test purposes!
 	 */
 	def enableTransitiveChangePropagation() {
 		shouldTransitivelyPropagateChanges = true
+	}
+
+	/**
+	 * Calling this method disables the transitive change propagation which may have been
+	 * enabled calling {@link #enableTransitiveChangePropagation()}.
+	 * Should only be called for test purposes!
+	 */
+	def disableTransitiveChangePropagation() {
+		shouldTransitivelyPropagateChanges = false
 	}
 	
 	override getDefaultLoadOptions() {

--- a/bundles/tools.vitruv.domains.pcm/src/tools/vitruv/domains/pcm/PcmDomain.xtend
+++ b/bundles/tools.vitruv.domains.pcm/src/tools/vitruv/domains/pcm/PcmDomain.xtend
@@ -20,11 +20,20 @@ final class PcmDomain extends AbstractVitruvDomain {
 	}
 
 	/**
-	 * Calling this methods enable the per default disabled transitive change propagation.
+	 * Calling this method enables the per default disabled transitive change propagation.
 	 * Should only be called for test purposes!
 	 */
 	def enableTransitiveChangePropagation() {
 		shouldTransitivelyPropagateChanges = true
+	}
+
+	/**
+	 * Calling this method disables the transitive change propagation which may have been
+	 * enabled calling {@link #enableTransitiveChangePropagation()}.
+	 * Should only be called for test purposes!
+	 */
+	def disableTransitiveChangePropagation() {
+		shouldTransitivelyPropagateChanges = false
 	}
 
 }

--- a/bundles/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/UmlDomain.xtend
+++ b/bundles/tools.vitruv.domains.uml/src/tools/vitruv/domains/uml/UmlDomain.xtend
@@ -17,13 +17,22 @@ class UmlDomain extends AbstractVitruvDomain {
 	override shouldTransitivelyPropagateChanges() {
 		return shouldTransitivelyPropagateChanges;
 	}
-	
+
 	/**
-	 * Calling this methods enable the per default disabled transitive change propagation.
+	 * Calling this method enables the per default disabled transitive change propagation.
 	 * Should only be called for test purposes!
 	 */
 	def enableTransitiveChangePropagation() {
 		shouldTransitivelyPropagateChanges = true
 	}
-	
+
+	/**
+	 * Calling this method disables the transitive change propagation which may have been
+	 * enabled calling {@link #enableTransitiveChangePropagation()}.
+	 * Should only be called for test purposes!
+	 */
+	def disableTransitiveChangePropagation() {
+		shouldTransitivelyPropagateChanges = false
+	}
+
 }


### PR DESCRIPTION
Adds methods for disabling transitive change propagation in the Java, UML and PCM domain.
This, in particular, allows to dynamically disable and enable transitive change propagation in tests.