### PR TITLE
Move state-based propagation to views

### DIFF
--- a/bundles/tools.vitruv.domains.java.ui/src/tools/vitruv/domains/java/ui/monitorededitor/JavaMonitoredEditor.xtend
+++ b/bundles/tools.vitruv.domains.java.ui/src/tools/vitruv/domains/java/ui/monitorededitor/JavaMonitoredEditor.xtend
@@ -38,197 +38,194 @@ import static com.google.common.base.Preconditions.checkState
  * and then propagated as state-based changes to the {@link VirtualModel}.
  */
 class JavaMonitoredEditor extends AbstractMonitoredEditor implements ChangeOperationListener, IStartup {
-	static val Logger log = Logger.getLogger(JavaMonitoredEditor)
+    static val Logger log = Logger.getLogger(JavaMonitoredEditor)
 
-	@Accessors(PUBLIC_GETTER)
-	val Set<String> monitoredProjectNames
-	@Accessors(PUBLIC_SETTER)
-	volatile boolean reportChanges
-	val ChangeClassifyingEventToResourceChangeConverter changeConverter
-	val RecordingState recordingState
-	val ASTChangeListener astListener
-	val Supplier<Boolean> shouldBeActive
+    @Accessors(PUBLIC_GETTER)
+    val Set<String> monitoredProjectNames
+    @Accessors(PUBLIC_SETTER)
+    volatile boolean reportChanges
+    val ChangeClassifyingEventToResourceChangeConverter changeConverter
+    val RecordingState recordingState
+    val ASTChangeListener astListener
+    val Supplier<Boolean> shouldBeActive
 
-	new(VirtualModel virtualModel, Supplier<Boolean> shouldBeActive, String... monitoredProjectNames) {
-		super(virtualModel)
-		checkState(PlatformUI.getWorkbench() !== null,
-			"Platform is not running but necessary for monitored Java editor")
-		log.debug('''Start initializing monitored Java editor for projects «monitoredProjectNames»''')
-		this.monitoredProjectNames = Set.of(monitoredProjectNames)
-		this.changeConverter = new ChangeClassifyingEventToResourceChangeConverter()
-		this.reportChanges = true
-		this.shouldBeActive = shouldBeActive
-		this.recordingState = new RecordingState([submitPropagationCheckJobIfNecessary])
-		astListener = new ASTChangeListener(this.monitoredProjectNames)
-		astListener.addListener(this)
-		log.trace('''Finished initializing monitored Java editor for projects «monitoredProjectNames»''')
-	}
+    new(VirtualModel virtualModel, Supplier<Boolean> shouldBeActive, String... monitoredProjectNames) {
+        super(virtualModel)
+        checkState(PlatformUI.getWorkbench() !== null,
+            "Platform is not running but necessary for monitored Java editor")
+        log.debug('''Start initializing monitored Java editor for projects «monitoredProjectNames»''')
+        this.monitoredProjectNames = Set.of(monitoredProjectNames)
+        this.changeConverter = new ChangeClassifyingEventToResourceChangeConverter()
+        this.reportChanges = true
+        this.shouldBeActive = shouldBeActive
+        this.recordingState = new RecordingState([submitPropagationCheckJobIfNecessary])
+        astListener = new ASTChangeListener(this.monitoredProjectNames)
+        astListener.addListener(this)
+        log.trace('''Finished initializing monitored Java editor for projects «monitoredProjectNames»''')
+    }
 
-	new(VirtualModel virtualModel, String... monitoredProjectNames) {
-		this(virtualModel, [true], monitoredProjectNames)
-	}
+    new(VirtualModel virtualModel, String... monitoredProjectNames) {
+        this(virtualModel, [true], monitoredProjectNames)
+    }
 
-	def void startMonitoring() {
-		astListener.startListening
-	}
+    def void startMonitoring() {
+        astListener.startListening
+    }
 
-	def void stopMonitoring() {
-		astListener.stopListening
-	}
+    def void stopMonitoring() {
+        astListener.stopListening
+    }
 
-	def private void submitPropagationCheckJobIfNecessary() {
-		if (automaticPropagationAfterMilliseconds == -1) {
-			return
-		}
-		log.trace('''Submitting propagation job for projects «monitoredProjectNames»''')
-		val changePropagationJob = new WorkspaceJob("Change propagation check job") {
-			override runInWorkspace(IProgressMonitor monitor) {
-				propagateRecordedChangesIfNecessary
-				return Status.OK_STATUS
-			}
-		}
-		changePropagationJob.setPriority(Job.SHORT)
-		// Defer change propagation while waiting for further changes to occur
-		changePropagationJob.schedule(automaticPropagationAfterMilliseconds)
-	}
+    def private void submitPropagationCheckJobIfNecessary() {
+        if (automaticPropagationAfterMilliseconds == -1) {
+            return
+        }
+        log.trace('''Submitting propagation job for projects «monitoredProjectNames»''')
+        val changePropagationJob = new WorkspaceJob("Change propagation check job") {
+            override runInWorkspace(IProgressMonitor monitor) {
+                propagateRecordedChangesIfNecessary
+                return Status.OK_STATUS
+            }
+        }
+        changePropagationJob.setPriority(Job.SHORT)
+        // Defer change propagation while waiting for further changes to occur
+        changePropagationJob.schedule(automaticPropagationAfterMilliseconds)
+    }
 
-	private def void propagateRecordedChangesIfNecessary() {
-		log.trace('''Checking for necessary change propagation in projects «monitoredProjectNames»''')
-		if (!recordingState.hasRecentlyBeenChanged()) {
-			submitChangePropagationJob
-		} else {
-			recordingState.touch()
-			submitPropagationCheckJobIfNecessary
-		}
-	}
+    private def void propagateRecordedChangesIfNecessary() {
+        log.trace('''Checking for necessary change propagation in projects «monitoredProjectNames»''')
+        if (!recordingState.hasRecentlyBeenChanged()) {
+            submitChangePropagationJob
+        } else {
+            recordingState.touch()
+            submitPropagationCheckJobIfNecessary
+        }
+    }
 
-	override void propagateRecordedChanges() {
-		log.debug('''Explicitly triggered change propagation for projects «monitoredProjectNames»''')
-		submitChangePropagationJob
-	}
+    override void propagateRecordedChanges() {
+        log.debug('''Explicitly triggered change propagation for projects «monitoredProjectNames»''')
+        submitChangePropagationJob
+    }
 
-	private def void submitChangePropagationJob() {
-		log.trace('''Submitting change propagation job for projects «monitoredProjectNames»''')
-		val changePropagationJob = new WorkspaceJob("Change propagation job") {
-			override runInWorkspace(IProgressMonitor monitor) {
-				internalPropagateRecordedChanges
-				return Status.OK_STATUS
-			}
-		}
-		changePropagationJob.setPriority(Job.BUILD)
-		changePropagationJob.schedule()
-	}
+    private def void submitChangePropagationJob() {
+        log.trace('''Submitting change propagation job for projects «monitoredProjectNames»''')
+        val changePropagationJob = new WorkspaceJob("Change propagation job") {
+            override runInWorkspace(IProgressMonitor monitor) {
+                internalPropagateRecordedChanges
+                return Status.OK_STATUS
+            }
+        }
+        changePropagationJob.setPriority(Job.BUILD)
+        changePropagationJob.schedule()
+    }
 
-	private def void internalPropagateRecordedChanges() {
-		log.debug('''Propagating «recordingState.changeCount» change(s) in projects «monitoredProjectNames»''')
-		val changes = recordingState.reset()
-		for (ResourceChange change : changes) {
-			val changedResource = if (change.newResourceURI !== null) {
-					try {
-						val changedResource = new ResourceSetImpl().getResource(change.newResourceURI, true)
-						// Resolve proxies to ensure that all elements can be found instead of treating proxies as new elements
-						EcoreUtil.resolveAll(changedResource)
-						changedResource
-					} catch (RuntimeException e) {
-						throw new IllegalStateException("Resource " + change.newResourceURI +
-							" was not found although it should exist")
-					}
-				}
-			//TODO This is just a workaround to access the previous resource state.
-			// The correct behavior would be to attach the Java monitor to a state-deriving view and reuse its change deriving functionality.
-			try (val view = getViewForURI(change.oldResourceURI ?: change.newResourceURI)) {
-			    val oldResource = view.rootObjects.head?.eResource
-			    val changeSequence = generateChange(changedResource, oldResource)
-			    virtualModel.propagateChange(changeSequence)
-			} catch (Exception e) {
-				log.error('''Some error occurred during propagating changes in projects «monitoredProjectNames»''', e)
-				throw new IllegalStateException(e)
-			}
-		}
-	}
-	
-	private def View getViewForURI(URI resourceURI) {
-	    val selector = virtualModel.createSelector(ViewTypeFactory.createIdentityMappingViewType("Java"))
+    private def void internalPropagateRecordedChanges() {
+        log.debug('''Propagating «recordingState.changeCount» change(s) in projects «monitoredProjectNames»''')
+        val changes = recordingState.reset()
+        for (ResourceChange change : changes) {
+            val changedResource = if (change.newResourceURI !== null) {
+                    try {
+                        val changedResource = new ResourceSetImpl().getResource(change.newResourceURI, true)
+                        // Resolve proxies to ensure that all elements can be found instead of treating proxies as new elements
+                        EcoreUtil.resolveAll(changedResource)
+                        changedResource
+                    } catch (RuntimeException e) {
+                        throw new IllegalStateException("Resource " + change.newResourceURI +
+                            " was not found although it should exist")
+                    }
+                }
+            // TODO This is just a workaround to access the previous resource state.
+            // The correct behavior would be to attach the Java monitor to a state-deriving view and reuse its change deriving functionality.
+            try (val view = getViewForURI(change.oldResourceURI ?: change.newResourceURI)) {
+                val oldResource = view.rootObjects.head?.eResource
+                val changeSequence = generateChange(changedResource, oldResource)
+                virtualModel.propagateChange(changeSequence)
+            } catch (Exception e) {
+                log.error('''Some error occurred during propagating changes in projects «monitoredProjectNames»''', e)
+                throw new IllegalStateException(e)
+            }
+        }
+    }
+
+    private def View getViewForURI(URI resourceURI) {
+        val selector = virtualModel.createSelector(ViewTypeFactory.createIdentityMappingViewType("Java"))
 
         for (rootElement : selector.selectableElements.filter[it.eResource?.URI == resourceURI]) {
             selector.setSelected(rootElement, true)
         }
         return selector.createView()
-	}
-	
-	private def VitruviusChange generateChange(Resource newState, Resource referenceState) {
-	    val changeResolutionStrategy = new DefaultStateBasedChangeResolutionStrategy
+    }
+
+    private def VitruviusChange generateChange(Resource newState, Resource referenceState) {
+        val changeResolutionStrategy = new DefaultStateBasedChangeResolutionStrategy
         if (referenceState === null) {
             return changeResolutionStrategy.getChangeSequenceForCreated(newState)
-        }
-        else if (newState === null) {
+        } else if (newState === null) {
             return changeResolutionStrategy.getChangeSequenceForDeleted(referenceState)
-        }
-        else {
+        } else {
             return changeResolutionStrategy.getChangeSequenceBetween(newState, referenceState)
         }
     }
 
-	override void notifyEventOccured() {
-		if (!shouldBeActive.get) {
-			stopMonitoring
-		}
-	}
+    override void notifyEventOccured() {
+        if (!shouldBeActive.get) {
+            stopMonitoring
+        }
+    }
 
-	override void notifyEventClassified(ChangeClassifyingEvent event) {
-		log.debug('''Monitored editor for projects «monitoredProjectNames» reacting to change «event»''')
-		val convertedChange = changeConverter.convert(event)
-		if (!this.reportChanges) {
-			log.
-				warn('''Do not report change «convertedChange» because reporting is disabled for projects «monitoredProjectNames»''')
-			return
-		}
-		log.trace('''Submit change in projects «monitoredProjectNames»''')
-		recordingState.submitChange(convertedChange)
-	}
+    override void notifyEventClassified(ChangeClassifyingEvent event) {
+        log.debug('''Monitored editor for projects «monitoredProjectNames» reacting to change «event»''')
+        val convertedChange = changeConverter.convert(event)
+        if (!this.reportChanges) {
+            log.
+                warn('''Do not report change «convertedChange» because reporting is disabled for projects «monitoredProjectNames»''')
+            return
+        }
+        log.trace('''Submit change in projects «monitoredProjectNames»''')
+        recordingState.submitChange(convertedChange)
+    }
 
-	override void earlyStartup() {
-	}
+    override void earlyStartup() {
+    }
 
-	private static class RecordingState {
-		val List<ResourceChange> changes = new ArrayList()
-		int lastChangeCount = 0
-		val ()=>void submitPropagation
+    private static class RecordingState {
+        val List<ResourceChange> changes = new ArrayList()
+        int lastChangeCount = 0
+        val ()=>void submitPropagation
 
-		new(()=>void submitPropagation) {
-			this.submitPropagation = submitPropagation
-		}
+        new(()=>void submitPropagation) {
+            this.submitPropagation = submitPropagation
+        }
 
-		def synchronized Iterable<ResourceChange> reset() {
-			val returnedChanges = new ArrayList(changes)
-			changes.clear()
-			lastChangeCount = 0
-			return returnedChanges
-		}
+        def synchronized Iterable<ResourceChange> reset() {
+            val returnedChanges = new ArrayList(changes)
+            changes.clear()
+            lastChangeCount = 0
+            return returnedChanges
+        }
 
-		def synchronized void submitChange(ResourceChange change) {
-			changes.add(change)
-			// If this is the first change, submit a propagation job
-			if (changes.size() === 1) {
-				submitPropagation.apply
-			}
-		}
+        def synchronized void submitChange(ResourceChange change) {
+            changes.add(change)
+            // If this is the first change, submit a propagation job
+            if (changes.size() === 1) {
+                submitPropagation.apply
+            }
+        }
 
-		def synchronized boolean hasRecentlyBeenChanged() {
-			return changes.size() !== lastChangeCount
-		}
+        def synchronized boolean hasRecentlyBeenChanged() {
+            return changes.size() !== lastChangeCount
+        }
 
-		def synchronized void touch() {
-			lastChangeCount = changes.size()
-		}
+        def synchronized void touch() {
+            lastChangeCount = changes.size()
+        }
 
-		def synchronized int getChangeCount() {
-			return changes.size()
-		}
+        def synchronized int getChangeCount() {
+            return changes.size()
+        }
 
-		def synchronized Iterable<ResourceChange> getChanges() {
-			return changes
-		}
-	}
-
+        def synchronized Iterable<ResourceChange> getChanges() {
+            return changes
+        }
+    }
 }


### PR DESCRIPTION
Supporting PR for [Vitruv#492](https://github.com/vitruv-tools/Vitruv/pull/492)

Replaces the state-based VSUM API access in the `JavaMonitoredEditor` by manually generating the changes based on the initial and changed view state and then propagating them using the delta-based VSUM API. 
The proposed solution should be considered only a workaround to avoid the state-based API and not a perfectly clean solution. This is due to the fact that the Java editor (as any editor) should be attached to a view and reuse its functionality instead of working on the internal files directly. However, this is out of scope for this PR.