### PR TITLE
Add local build Maven profile

### DIFF
--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -51,7 +51,7 @@ jobs:
           working-directory: ./cbsapplications
           run: >
             ./mvnw -B clean verify
-            -Dvitruv.domains.path='/${maven.multiModuleProjectDirectory}/../cbsdomains'
+            -Dvitruv.domains.path=${maven.multiModuleProjectDirectory}/../cbsdomains
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -32,10 +32,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Adapt Updatesites
-        run: |
-          sed -i 's#https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/#file:///${maven.multiModuleProjectDirectory}/../cbsdomains/releng/tools.vitruv.domains.cbs.updatesite.aggregated/target/final#wresult' cbsapplications/releng/tools.vitruv.applications.cbs.parent/pom.xml
-          if [ ! -s result ]; then exit 1; fi;
       - name: Build Domains
         working-directory: ./cbsdomains
         run: >
@@ -55,6 +51,7 @@ jobs:
           working-directory: ./cbsapplications
           run: >
             ./mvnw -B clean verify
+            -Dvitruv.domains.path='/${maven.multiModuleProjectDirectory}/../cbsdomains'
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn

--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -2,6 +2,25 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
+	<profiles>
+		<profile>
+			<id>nightly-update-site</id>
+			<activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+			<properties>
+				<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
+			</properties>
+		</profile>
+
+		<profile>
+			<id>local</id>
+			<properties>
+				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
+			</properties>
+		</profile>
+	</profiles>
+
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>tools.vitruv</groupId>
@@ -17,7 +36,7 @@
 		<repository>
 			<id>Vitruv Framework</id>
 			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/nightly/framework/</url>
+			<url>${vitruv.framework.url}</url>
 		</repository>
 		<repository>
 			<id>SDQ Commons</id>

--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -50,10 +50,10 @@
 		<profile>
 			<id>local</id>
 			<activation>
-     			<property>
-        			<name>vitruv.framework.path</name>
-      			</property>
-      		</activation>
+				<property>
+					<name>vitruv.framework.path</name>
+				</property>
+			</activation>
 			<properties>
 				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
 			</properties>

--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -2,32 +2,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<profiles>
-		<profile>
-			<id>nightly-update-site</id>
-			<activation>
-     			<property>
-        			<name>!vitruv.framework.path</name>
-      			</property>
-      		</activation>
-			<properties>
-				<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
-			</properties>
-		</profile>
-
-		<profile>
-			<id>local</id>
-			<activation>
-     			<property>
-        			<name>vitruv.framework.path</name>
-      			</property>
-      		</activation>
-			<properties>
-				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
-			</properties>
-		</profile>
-	</profiles>
-
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>tools.vitruv</groupId>
@@ -37,6 +11,10 @@
 	<artifactId>domains-parent</artifactId>
 	<version>2.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
+
+	<properties>
+		<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
+	</properties>
 
 	<repositories>
 		<!-- If you adjust a repository here, please also adjust the repository in the b3 aggregator. -->
@@ -67,5 +45,19 @@
 			<url>https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/5.0.0/</url>
 		</repository>
 	</repositories>
+
+	<profiles>
+		<profile>
+			<id>local</id>
+			<activation>
+     			<property>
+        			<name>vitruv.framework.path</name>
+      			</property>
+      		</activation>
+			<properties>
+				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
+			</properties>
+		</profile>
+	</profiles>
 
 </project>

--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -6,8 +6,10 @@
 		<profile>
 			<id>nightly-update-site</id>
 			<activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
+     			<property>
+        			<name>!vitruv.framework.path</name>
+      			</property>
+      		</activation>
 			<properties>
 				<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
 			</properties>
@@ -15,6 +17,11 @@
 
 		<profile>
 			<id>local</id>
+			<activation>
+     			<property>
+        			<name>vitruv.framework.path</name>
+      			</property>
+      		</activation>
 			<properties>
 				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
 			</properties>


### PR DESCRIPTION
This PR adds a local build Maven profile as described in [Vitruv#510](https://github.com/vitruv-tools/Vitruv/issues/510).

While the simpler solution would have been to not use a profile but rather only the `vitruv.framework.url` property, this would have required from the user to include the entire url `file://<path_to_vitruv_folder>/releng/tools.vitruv.updatesite.aggregated/target/final` when calling. I chose to integrate a profile such that only the path to the Vitruv directory, instead of to the actual update site, can be provided. If the update site is at the expected relative path in the Vitruv folder, one can still customize the entire url by calling `-Dvitruv.framework.url='<url>'`.

### Usage:
`mvn clean verify -Dvitruv.framework.path='<path_to_vitruv_folder>'`

### Requires

⚠️ Requires [Vitruv-Applications#188](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/pull/188) to be merged first ⚠️ 