### PR TITLE
GitHub actions update

### DIFF
--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -52,7 +52,7 @@ jobs:
           working-directory: ./cbsapplications
           run: >
             ./mvnw -B clean verify
-            -Dvitruv.domains.path=${maven.multiModuleProjectDirectory}/../cbsdomains
+            -Dvitruv.domains.path=${GITHUB_WORKSPACE}/cbsdomains
             -Dstyle.color=always
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
             -Dorg.slf4j.simpleLogger.log.org.eclipse.tycho.core.resolver.DefaultTychoResolver=warn

--- a/.github/workflows/applicationsvalidation.yml
+++ b/.github/workflows/applicationsvalidation.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CBS Domains
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: cbsdomains
       - name: Checkout CBS Applications
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: cbsapplications
           repository: vitruv-tools/Vitruv-Applications-ComponentBasedSystems
@@ -23,14 +23,15 @@ jobs:
           cd cbsapplications
           git checkout -B ${{ github.head_ref }} origin/${{ github.head_ref }} || true
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Build Domains
         working-directory: ./cbsdomains

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Build and Verify
         run: ./mvnw -B clean verify


### PR DESCRIPTION
Updates the GitHub actions primarily to avoid the undocumented `maven.multiModuleProjectDirectory` variable.

> This variable is only used in the mvn script and is neither documented nor intended for public used (internal implementation detail). So I strongly recommend not to use it. Otherwise things might break in the future.

[Quote source](https://stackoverflow.com/questions/29778262/what-is-maven-multimoduleprojectdirectory-used-for)

Additionally, versions of used GitHub actions are updated.
As of `setup-java@v2` the Java distribution needs to be specified. I chose to preserve the default value of v1 which was `Zulu` but I am open for discussion to use other Java distributions which should be held in [Vitruv#525](https://github.com/vitruv-tools/Vitruv/pull/525).