### PR TITLE
Correct file URI in parent pom

### DIFF
--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -55,7 +55,7 @@
 				</property>
 			</activation>
 			<properties>
-				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite/target/repository</vitruv.framework.url>
+				<vitruv.framework.url>file:///${vitruv.framework.path}/releng/tools.vitruv.updatesite/target/repository</vitruv.framework.url>
 			</properties>
 		</profile>
 	</profiles>


### PR DESCRIPTION
Corrects the file URI scheme used in the parent pom to use a local repository
Previous `file://`, now `file:///`
[File URI scheme description](https://en.wikipedia.org/wiki/File_URI_scheme)