### PR TITLE
Add changes updatesite and path parameter

### DIFF
--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -13,11 +13,18 @@
 	<packaging>pom</packaging>
 
 	<properties>
+		<!-- For each project, a local updatesite can be specified by overwriting these properties. They default to the Vitruv updatesites. -->
+		<vitruv.change.url>https://vitruv-tools.github.io/updatesite/nightly/change/</vitruv.change.url>
 		<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
 	</properties>
 
 	<repositories>
-		<!-- If you adjust a repository here, please also adjust the repository in the b3 aggregator. -->
+		<!-- The Vitruv project updatesites to be potentially overwritten by local builds -->
+		<repository>
+			<id>Vitruv Change</id>
+			<layout>p2</layout>
+			<url>${vitruv.change.url}</url>
+		</repository>
 		<repository>
 			<id>Vitruv Framework</id>
 			<layout>p2</layout>
@@ -42,7 +49,19 @@
 
 	<profiles>
 		<profile>
-			<id>local</id>
+			<id>local-change</id>
+			<activation>
+				<property>
+					<name>vitruv.change.path</name>
+				</property>
+			</activation>
+			<properties>
+				<vitruv.change.url>file:///${vitruv.change.path}/releng/tools.vitruv.change.updatesite/target/repository</vitruv.change.url>
+			</properties>
+		</profile>
+		
+		<profile>
+			<id>local-framework</id>
 			<activation>
 				<property>
 					<name>vitruv.framework.path</name>


### PR DESCRIPTION
This PR adds a property for the changes updatesite repository, such that it can be referenced in a local build of that site.
It also remove the unnecessary aggregated updatesite of Vitruv.