### PR TITLE
Remove explicit version from dependency updatesite

### DIFF
--- a/releng/tools.vitruv.domains.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.domains.cbs.parent/pom.xml
@@ -26,14 +26,8 @@
 		<repository>
 			<id>SDQ Commons</id>
 			<layout>p2</layout>
-			<url>https://kit-sdq.github.io/updatesite/release/commons/2.0.0/</url>
+			<url>https://kit-sdq.github.io/updatesite/release/commons/</url>
 		</repository>
-		<!--EMFText repository currently not available
-		<repository>
-			<id>EMFText</id>
-			<layout>p2</layout>
-			<url>http://update.emftext.org/release</url>
-		</repository>-->
 		<repository>
 			<id>EMFText and JaMoPP (P2 Wrapper)</id>
 			<layout>p2</layout>


### PR DESCRIPTION
Removes the explicit version in the updatesite URL for the SDQ Commons dependencies to ensure that always the latest available version is used.